### PR TITLE
Make tests pass in JDK 11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Tests are not passing right now in master, when compiling in JDK 11.
This is because tests in ``DefaultProjectDependencyAnalyzerTest`` call ``org.apache.commons.lang3.SystemUtils#isJavaVersionAtLeast`` which does not support Java 11 in common-lang3 version 3.7.
Bumping common-lang3 version to 3.8.1 resolves the issue.