### PR TITLE
[MSHARED-786] jdk8 incompatibility at runtime (NoSuchMethodError)

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -19,6 +19,7 @@ package org.apache.maven.shared.dependency.analyzer.asm;
  * under the License.
  */
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Collections;
@@ -159,8 +160,10 @@ public class ConstantPoolParser
 
     private static String decodeString( ByteBuffer buf )
     {
-        int size = buf.getChar(), oldLimit = buf.limit();
-        buf.limit( buf.position() + size );
+        int size = buf.getChar();
+        // Explicit cast for compatibility with covariant return type on JDK 9's ByteBuffer
+        int oldLimit = ( (Buffer) buf ).limit();
+        ( (Buffer) buf ).limit( buf.position() + size );
         StringBuilder sb = new StringBuilder( size + ( size >> 1 ) + 16 );
         while ( buf.hasRemaining() )
         {
@@ -183,7 +186,7 @@ public class ConstantPoolParser
                 }
             }
         }
-        buf.limit( oldLimit );
+        ( (Buffer) buf ).limit( oldLimit );
         return sb.toString();
     }
 }


### PR DESCRIPTION
 - explicit cast in Buffer for limit method to avoid runtim issue with jdk8

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHARED) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes. Also be sure having selected the correct component.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MSHARED-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHARED-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X on windows10] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically. 
 - [X on windows10] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

I got an icla

Regards

