### PR TITLE
[MSHARED-785] Make ConstantPoolParser ignore classes in unnamed package

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -153,7 +153,13 @@ public class ConstantPoolParser
         Set<String> result = new HashSet<String>();
         for ( Integer aClass : classes )
         {
-            result.add( stringConstants.get( aClass ) );
+            String className = stringConstants.get( aClass );
+
+            // filter out things from the default package, probably a false-positive
+            if ( isImportableClass( className ) )
+            {
+                result.add( className );
+            }
         }
         return result;
     }
@@ -188,5 +194,11 @@ public class ConstantPoolParser
         }
         ( (Buffer) buf ).limit( oldLimit );
         return sb.toString();
+    }
+
+    private static boolean isImportableClass( String className )
+    {
+        // without a slash, class must be in unnamed package, which can't be imported
+        return className.indexOf( '/' ) != -1;
     }
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -155,7 +155,7 @@ public class ConstantPoolParser
         {
             String className = stringConstants.get( aClass );
 
-            // filter out things from the default package, probably a false-positive
+            // filter out things from unnamed package, probably a false-positive
             if ( isImportableClass( className ) )
             {
                 result.add( className );

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -427,6 +427,32 @@ public class DefaultProjectDependencyAnalyzerTest
         assertEquals( expectedAnalysis, actualAnalysis );
     }
 
+    public void testUnnamedPackageClassReference()
+        throws TestToolsException, ProjectDependencyAnalyzerException
+    {
+        if ( !SystemUtils.isJavaVersionAtLeast( JavaVersion.JAVA_1_8 ) )
+        {
+            return;
+        }
+
+        // Only visible through constant pool analysis (supported for JDK8+)
+        compileProject( "unnamedPackageClassReference/pom.xml" );
+
+        MavenProject project = getProject( "unnamedPackageClassReference/pom.xml" );
+
+        ProjectDependencyAnalysis actualAnalysis = analyzer.analyze( project );
+
+        Artifact dnsjava = createArtifact( "dnsjava", "dnsjava", "jar", "2.1.8", "compile" );
+        // we don't use any dnsjava classes so this should show up as an unused dep
+        Set<Artifact> unusedDeclaredArtifacts = Collections.singleton( dnsjava );
+
+        ProjectDependencyAnalysis expectedAnalysis =
+            new ProjectDependencyAnalysis( new HashSet<Artifact>(), new HashSet<Artifact>(), unusedDeclaredArtifacts,
+                new HashSet<Artifact>() );
+
+        assertEquals( expectedAnalysis, actualAnalysis );
+    }
+
     // private methods --------------------------------------------------------
 
     private void compileProject( String pomPath )

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -43,6 +43,7 @@ import org.apache.maven.shared.test.plugin.ProjectTool;
 import org.apache.maven.shared.test.plugin.RepositoryTool;
 import org.apache.maven.shared.test.plugin.TestToolsException;
 import org.codehaus.plexus.PlexusTestCase;
+import org.junit.Assume;
 
 /**
  * Tests <code>DefaultProjectDependencyAnalyzer</code>.
@@ -430,10 +431,7 @@ public class DefaultProjectDependencyAnalyzerTest
     public void testUnnamedPackageClassReference()
         throws TestToolsException, ProjectDependencyAnalyzerException
     {
-        if ( !SystemUtils.isJavaVersionAtLeast( JavaVersion.JAVA_1_8 ) )
-        {
-            return;
-        }
+        Assume.assumeTrue( SystemUtils.isJavaVersionAtLeast( JavaVersion.JAVA_1_8 ) );
 
         // Only visible through constant pool analysis (supported for JDK8+)
         compileProject( "unnamedPackageClassReference/pom.xml" );

--- a/src/test/resources/unnamedPackageClassReference/pom.xml
+++ b/src/test/resources/unnamedPackageClassReference/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>unnamedPackageClassReference</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>2.1.8</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/unnamedPackageClassReference/src/main/java/unnamedPackageClassReference/Project.java
+++ b/src/test/resources/unnamedPackageClassReference/src/main/java/unnamedPackageClassReference/Project.java
@@ -1,0 +1,31 @@
+package unnamedPackageClassReference;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Project
+{
+    // dnsjava 2.1.8 includes a class called "update"
+    public static final String UPDATE = "update";
+
+    public Project()
+    {
+        // no op
+    }
+}


### PR DESCRIPTION
The ConstantPoolParser is looking for strings in the constant pool and treating them as references to a class which normally works fine, but it can create false-positives. The most common one we've run into is when there are classes in the unnamed package. For example, dnsjava has a class named update.java:
https://github.com/dnsjava/dnsjava/blob/0e56f37f320793ade4673cb2eaad159bc81d4a8a/update.java

So if you happen to have a string constant named `"update"`,  the dependency analyzer is fooled into thinking that this is a reference to update.java from dnsjava.

This PR mitigates the most common case by telling the ConstantPoolParser to ignore strings without a slash, as this should always correspond to a class in the unnamed package. This should never cause a false-negative, as according to the [JLS](https://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.5):
> types in an unnamed package cannot be imported

-----------------------------------------------------------------------------

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MSHARED) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes. Also be sure having selected the correct component.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MSHARED-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MSHARED-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`). (`[WARNING] The requested profile "run-its" could not be activated because it does not exist.`)

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

