### PR TITLE
MSHARED-1037: CONSTANT_METHOD_TYPE should not add to classes

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -124,10 +124,12 @@ public class ConstantPoolParser
                     throw new RuntimeException( "Unknown constant pool type '" + tag + "'" );
                 case CONSTANT_UTF8:
                     stringConstants.put( ix, decodeString( buf ) );
-                    continue;
+                    break;
                 case CONSTANT_CLASS:
-                case CONSTANT_METHOD_TYPE:
                     classes.add( (int) buf.getChar() );
+                    break;
+                case CONSTANT_METHOD_TYPE:
+                    consumeMethodType( buf );
                     break;
                 case CONSTANT_FIELDREF:
                 case CONSTANT_METHODREF:
@@ -217,6 +219,11 @@ public class ConstantPoolParser
     {
         // without a slash, class must be in unnamed package, which can't be imported
         return className.indexOf( '/' ) != -1;
+    }
+
+    private static void consumeMethodType( ByteBuffer buf )
+    {
+        buf.getChar();
     }
 
     private static void consumeReference( ByteBuffer buf )

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.util.Set;
 
 import org.apache.maven.shared.dependency.analyzer.testcases.ArrayCases;
+import org.apache.maven.shared.dependency.analyzer.testcases.MethodHandleCases;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
@@ -52,5 +53,16 @@ public class ResultCollectorTest
         assertThat( dependencies )
             .contains( "java.lang.annotation.Annotation" )
             .contains( "java.lang.reflect.Constructor" );
+    }
+
+    @Test
+    public void testNoMethodHandle()
+        throws IOException
+    {
+        Set<String> dependencies = getDependencies( MethodHandleCases.class );
+        for ( String dependency : dependencies )
+        {
+            assertThat( dependency ).doesNotStartWith( "(" );
+        }
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/MethodHandleCases.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/MethodHandleCases.java
@@ -1,0 +1,41 @@
+package org.apache.maven.shared.dependency.analyzer.testcases;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.function.Consumer;
+
+public class MethodHandleCases
+{
+    public void sayHello()
+    {
+        sayHello( this::callSite );
+    }
+
+    void sayHello( Consumer<String> consumer )
+    {
+        consumer.accept( "hello" );
+    }
+
+    private void callSite( String output )
+    {
+        System.out.println( output );
+    }
+
+}


### PR DESCRIPTION
In ConstantPoolParser, method type signatures should not be added as a class dependency

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

