### PR TITLE
MSHARED-1038: Inner classes are in same compilation unit as container class

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
@@ -45,7 +45,11 @@ public class CollectorClassFileVisitor
     /** {@inheritDoc} */
     public void visitClass( String className, InputStream in )
     {
-        classes.add( className );
+        // inner classes have equivalent compilation requirement as container class
+        if ( className.indexOf( '$' ) < 0 )
+        {
+            classes.add( className );
+        }
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -105,7 +105,11 @@ public class ResultCollector
      */
     public void add( String name )
     {
-        classes.add( name );
+        // inner classes have equivalent compilation requirement as container class
+        if ( name.indexOf( '$' ) < 0 )
+        {
+            classes.add( name );
+        }
     }
 
     void addNames( final String[] names )

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.util.Set;
 
 import org.apache.maven.shared.dependency.analyzer.testcases.ArrayCases;
+import org.apache.maven.shared.dependency.analyzer.testcases.InnerClassCase;
 import org.apache.maven.shared.dependency.analyzer.testcases.MethodHandleCases;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
@@ -64,5 +65,17 @@ public class ResultCollectorTest
         {
             assertThat( dependency ).doesNotStartWith( "(" );
         }
+    }
+
+    @Test
+    public void testInnerClassAsContainer()
+        throws IOException
+    {
+        Set<String> dependencies = getDependencies( InnerClassCase.class );
+        for ( String dependency : dependencies )
+        {
+            assertThat( dependency ).doesNotContain( "$" );
+        }
+        assertThat( dependencies ).contains( "java.lang.System" );
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/InnerClassCase.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/InnerClassCase.java
@@ -1,0 +1,30 @@
+package org.apache.maven.shared.dependency.analyzer.testcases;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.function.Consumer;
+
+public class InnerClassCase
+{
+    public Consumer<String> echoThis()
+    {
+        return ( s ) -> System.out.println( s );
+    }
+}


### PR DESCRIPTION
Fold inner class dependency into container class

 - [ x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

