### PR TITLE
MSHARED-1039: Fix array parsing

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -19,10 +19,10 @@ package org.apache.maven.shared.dependency.analyzer.asm;
  * under the License.
  */
 
-import org.objectweb.asm.Type;
-
 import java.util.HashSet;
 import java.util.Set;
+
+import org.objectweb.asm.Type;
 
 /**
  * <p>ResultCollector class.</p>
@@ -57,15 +57,24 @@ public class ResultCollector
         }
 
         // decode arrays
-        if ( name.startsWith( "[L" ) && name.endsWith( ";" ) )
+        if ( name.charAt( 0 ) == '[' )
         {
-            name = name.substring( 2, name.length() - 1 );
+            int i = 0;
+            do
+            {
+                ++i;
+            }
+            while ( name.charAt( i ) == '[' ); // could have array of array ...
+            if ( name.charAt( i ) != 'L' )
+            {
+                // ignore array of scalar types
+                return;
+            }
+            name = name.substring( i + 1, name.length() - 1 );
         }
 
         // decode internal representation
-        name = name.replace( '/', '.' );
-
-        classes.add( name );
+        add( name.replace( '/', '.' ) );
     }
 
     void addDesc( final String desc )
@@ -82,7 +91,7 @@ public class ResultCollector
                 break;
 
             case Type.OBJECT:
-                addName( t.getClassName().replace( '.', '/' ) );
+                addName( t.getClassName() );
                 break;
 
             default:

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
@@ -1,0 +1,56 @@
+package org.apache.maven.shared.dependency.analyzer.asm;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import org.apache.maven.shared.dependency.analyzer.testcases.ArrayCases;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+
+public class ResultCollectorTest
+{
+    Set<String> getDependencies( Class<?> inspectClass )
+        throws IOException
+    {
+        String className = inspectClass.getName();
+        String path = '/' + className.replace( '.', '/' ) + ".class";
+        DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
+        try ( InputStream is = inspectClass.getResourceAsStream( path ) )
+        {
+            visitor.visitClass( className, is );
+        }
+        return visitor.getDependencies();
+    }
+
+    @Test
+    public void testArrayCases()
+        throws IOException
+    {
+        Set<String> dependencies = getDependencies( ArrayCases.class );
+        assertThat( dependencies ).doesNotContain( "[I" );
+        assertThat( dependencies ).allSatisfy( dependency -> assertThat( dependency ).doesNotStartWith( "[" ) );
+        assertThat( dependencies )
+            .contains( "java.lang.annotation.Annotation" )
+            .contains( "java.lang.reflect.Constructor" );
+    }
+}

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/ArrayCases.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/testcases/ArrayCases.java
@@ -1,0 +1,55 @@
+package org.apache.maven.shared.dependency.analyzer.testcases;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+
+import org.apache.maven.shared.dependency.analyzer.asm.DefaultMethodVisitor;
+
+public class ArrayCases
+{
+    /**
+     * Cause {@link DefaultMethodVisitor#visitMethodInsn(int, String, String, String, boolean)} to be called
+     * with primitive array
+     * @param source
+     * @return
+     */
+    public int[] primitive( int[] source )
+    {
+        // causes
+        return source.clone();
+    }
+
+    public <T> void arrayOfArrayCollectedAsReference( Class<T> cls )
+    {
+        Constructor<?>[] constructors = cls.getConstructors();
+        for ( Constructor<?> constructor : constructors )
+        {
+            for ( Annotation[] parameters : constructor.getParameterAnnotations() )
+            {
+                for ( Annotation annotation : parameters )
+                {
+                    System.out.println("Class: "+cls+", Annotation: "+ annotation );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Arrays [of Arrays]+ of class types should add just the class type to dependency set

Arrays of scalar types should not be added


 - [ x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

