### PR TITLE
[MSHARED-1149] – Replace System.out by logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 
   <properties>
     <mavenVersion>3.2.5</mavenVersion>
+    <slf4jVersion>1.7.36</slf4jVersion>
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2022-08-20T15:25:47Z</project.build.outputTimestamp>
     <!-- TODO check with next parent -->
@@ -90,6 +91,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4jVersion}</version>
+    </dependency>
+
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.11.0</version>
@@ -106,6 +113,12 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.24.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4jVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
@@ -30,6 +30,8 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.signature.SignatureVisitor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Computes the set of classes referenced by visited class files, using
@@ -40,6 +42,8 @@ import org.objectweb.asm.signature.SignatureVisitor;
  */
 public class DependencyClassFileVisitor implements ClassFileVisitor {
     private final ResultCollector resultCollector = new ResultCollector();
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**
      * <p>Constructor for DependencyClassFileVisitor.</p>
@@ -70,7 +74,7 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
         } catch (IndexOutOfBoundsException e) {
             // some bug inside ASM causes an IOB exception. Log it and move on?
             // this happens when the class isn't valid.
-            System.out.println("Unable to process: " + className);
+            logger.warn("Unable to process: " + className);
         }
     }
 


### PR DESCRIPTION
Replace usage of `System.out.println` by Logger from slf4j. 
Introducing slf4j in similar way like other MSHARED projects like maven-filtering

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

