### PR TITLE
[MSHARED-47] Don't flag xml-apis:xml-apis as undeclared

### DIFF
--- a/src/it/jarWithXmlTransitiveDependency/verify.groovy
+++ b/src/it/jarWithXmlTransitiveDependency/verify.groovy
@@ -24,8 +24,6 @@ UsedDeclaredArtifacts:
  dom4j:dom4j:jar:1.6.1:compile
 
 UsedUndeclaredArtifactsWithClasses:
- xml-apis:xml-apis:jar:1.0.b2:compile
-  org.xml.sax.Parser
 
 UnusedDeclaredArtifacts:
 

--- a/src/it/usedUndeclaredReference/verify.groovy
+++ b/src/it/usedUndeclaredReference/verify.groovy
@@ -23,8 +23,6 @@ def expected = '''
 UsedDeclaredArtifacts:
 
 UsedUndeclaredArtifactsWithClasses:
- xml-apis:xml-apis:jar:1.0.b2:compile
-  org.apache.xmlcommons.Version
 
 UnusedDeclaredArtifacts:
  dom4j:dom4j:jar:1.6.1:compile

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -243,8 +243,6 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         for (DependencyUsage classUsage : dependencyClasses) {
             Artifact artifact = findArtifactForClassName(artifactClassMap, classUsage.getDependencyClass());
 
-            // MSHARED-47 xml-apis:xml-apis is an uncommon case where a commonly used
-            // third party dependency was added to the JDK
             if (artifact != null && !includedInJDK(artifact)) {
                 Set<DependencyUsage> classesFromArtifact = usedArtifacts.get(artifact);
                 if (classesFromArtifact == null) {
@@ -258,6 +256,8 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return usedArtifacts;
     }
 
+    // MSHARED-47 an uncommon case where a commonly used
+    // third party dependency was added to the JDK
     private static boolean includedInJDK(Artifact artifact) {
         if ("xml-apis".equals(artifact.getGroupId())) {
             if ("xml-apis".equals(artifact.getArtifactId())) {

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -245,7 +245,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
 
             // MSHARED-47 xml-apis:xml-apis is an uncommon case where a commonly used
             // third party dependency was added to the JDK
-            if (artifact != null && !"xml-apis".equals(artifact.getArtifactId())) {
+            if (artifact != null && !includedInJDK(artifact)) {
                 Set<DependencyUsage> classesFromArtifact = usedArtifacts.get(artifact);
                 if (classesFromArtifact == null) {
                     classesFromArtifact = new HashSet<>();
@@ -256,6 +256,19 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         }
 
         return usedArtifacts;
+    }
+
+    private static boolean includedInJDK(Artifact artifact) {
+        if ("xml-apis".equals(artifact.getGroupId())) {
+            if ("xml-apis".equals(artifact.getArtifactId())) {
+                return true;
+            }
+        } else if ("xerces".equals(artifact.getGroupId())) {
+            if ("xmlParserAPIs".equals(artifact.getArtifactId())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Artifact findArtifactForClassName(Map<Artifact, Set<String>> artifactClassMap, String className) {

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -99,6 +99,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             Map<Artifact, Set<DependencyUsage>> usedUndeclaredArtifactsWithClasses = new LinkedHashMap<>(usedArtifacts);
             Set<Artifact> usedUndeclaredArtifacts =
                     removeAll(usedUndeclaredArtifactsWithClasses.keySet(), declaredArtifacts);
+
             usedUndeclaredArtifactsWithClasses.keySet().retainAll(usedUndeclaredArtifacts);
 
             Set<Artifact> unusedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
@@ -242,7 +243,9 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         for (DependencyUsage classUsage : dependencyClasses) {
             Artifact artifact = findArtifactForClassName(artifactClassMap, classUsage.getDependencyClass());
 
-            if (artifact != null) {
+            // MSHARED-47 xml-apis:xml-apis is an uncommon case where a commonly used
+            // third party dependency was added to the JDK
+            if (artifact != null && !"xml-apis".equals(artifact.getArtifactId())) {
                 Set<DependencyUsage> classesFromArtifact = usedArtifacts.get(artifact);
                 if (classesFromArtifact == null) {
                     classesFromArtifact = new HashSet<>();


### PR DESCRIPTION
since these classes have been bundled in the JDK since the 2000s.

This misses a few edge cases like org.apache.xmlcommons.Version which is not included in the JDK and is in xml-apis, but it fixes many more false positives than it creates false negatives. 