### PR TITLE
Handle corrupt constant pools

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
@@ -65,11 +65,11 @@ public class ProjectDependencyAnalysis {
             Set<Artifact> usedDeclaredArtifacts,
             Set<Artifact> usedUndeclaredArtifacts,
             Set<Artifact> unusedDeclaredArtifacts) {
-        this(usedDeclaredArtifacts, usedUndeclaredArtifacts, unusedDeclaredArtifacts, Collections.<Artifact>emptySet());
+        this(usedDeclaredArtifacts, usedUndeclaredArtifacts, unusedDeclaredArtifacts, Collections.emptySet());
     }
 
     /**
-     * <p>Constructor for ProjectDependencyAnalysis.</p>
+     * Constructor for ProjectDependencyAnalysis.
      *
      * @param usedDeclaredArtifacts artifacts both used and declared
      * @param usedUndeclaredArtifacts artifacts used but not declared
@@ -343,7 +343,7 @@ public class ProjectDependencyAnalysis {
         Map<Artifact, Set<DependencyUsage>> map = new LinkedHashMap<>();
 
         for (Artifact k : keys) {
-            map.put(k, Collections.<DependencyUsage>emptySet());
+            map.put(k, CollectionsemptySet());
         }
 
         return map;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
@@ -343,7 +343,7 @@ public class ProjectDependencyAnalysis {
         Map<Artifact, Set<DependencyUsage>> map = new LinkedHashMap<>();
 
         for (Artifact k : keys) {
-            map.put(k, CollectionsemptySet());
+            map.put(k, Collections.emptySet());
         }
 
         return map;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -33,7 +33,7 @@ import org.objectweb.asm.Type;
  * A small parser to read the constant pool directly, in case it contains references
  * ASM does not support.
  *
- * Adapted from http://stackoverflow.com/a/32278587/23691
+ * Adapted from <a href="https://stackoverflow.com/questions/32255023/how-would-i-go-about-parsing-the-java-class-file-constant-pool/32278587#32278587">Stack Overflow</a>
  *
  * Constant pool types:
  *
@@ -108,7 +108,7 @@ public class ConstantPoolParser {
         return parseConstantPoolClassReferences(ByteBuffer.wrap(b));
     }
 
-    static Set<String> parseConstantPoolClassReferences(ByteBuffer buf) {
+    private static Set<String> parseConstantPoolClassReferences(ByteBuffer buf) {
         if (buf.order(ByteOrder.BIG_ENDIAN).getInt() != HEAD) {
             return Collections.emptySet();
         }
@@ -203,12 +203,12 @@ public class ConstantPoolParser {
         }
     }
 
+    @SuppressWarnings("RedundantCast")
     private static String decodeString(ByteBuffer buf) {
         int size = buf.getChar();
+        int oldLimit = buf.limit();
         // Explicit cast for compatibility with covariant return type on JDK 9's ByteBuffer
-        @SuppressWarnings("RedundantCast")
-        int oldLimit = ((Buffer) buf).limit();
-        buf.limit(buf.position() + size);
+        ((Buffer) buf).limit(buf.position() + size);
         StringBuilder sb = new StringBuilder(size + (size >> 1) + 16);
         while (buf.hasRemaining()) {
             byte b = buf.get();
@@ -224,7 +224,7 @@ public class ConstantPoolParser {
                 }
             }
         }
-        buf.limit(oldLimit);
+        ((Buffer) buf).limit(oldLimit);
         return sb.toString();
     }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -208,7 +208,7 @@ public class ConstantPoolParser {
         // Explicit cast for compatibility with covariant return type on JDK 9's ByteBuffer
         @SuppressWarnings("RedundantCast")
         int oldLimit = ((Buffer) buf).limit();
-        ((Buffer) buf).limit(buf.position() + size);
+        buf.limit(buf.position() + size);
         StringBuilder sb = new StringBuilder(size + (size >> 1) + 16);
         while (buf.hasRemaining()) {
             byte b = buf.get();
@@ -224,7 +224,7 @@ public class ConstantPoolParser {
                 }
             }
         }
-        ((Buffer) buf).limit(oldLimit);
+        buf.limit(oldLimit);
         return sb.toString();
     }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -120,8 +120,6 @@ public class ConstantPoolParser {
         for (int ix = 1, num = buf.getChar(); ix < num; ix++) {
             byte tag = buf.get();
             switch (tag) {
-                default:
-                    throw new RuntimeException("Unknown constant pool type '" + tag + "'");
                 case CONSTANT_UTF8:
                     stringConstants.put(ix, decodeString(buf));
                     break;
@@ -172,6 +170,8 @@ public class ConstantPoolParser {
                 case CONSTANT_PACKAGE:
                     consumePackage(buf);
                     break;
+                default:
+                    throw new RuntimeException("Unknown constant pool type '" + tag + "'");
             }
         }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.dependency.analyzer.asm;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -104,11 +105,11 @@ public class ConstantPoolParser {
 
     private static final int OX3F = 0x3F;
 
-    static Set<String> getConstantPoolClassReferences(byte[] b) {
+    static Set<String> getConstantPoolClassReferences(byte[] b) throws ParseException {
         return parseConstantPoolClassReferences(ByteBuffer.wrap(b));
     }
 
-    private static Set<String> parseConstantPoolClassReferences(ByteBuffer buf) {
+    private static Set<String> parseConstantPoolClassReferences(ByteBuffer buf) throws ParseException {
         if (buf.order(ByteOrder.BIG_ENDIAN).getInt() != HEAD) {
             return Collections.emptySet();
         }
@@ -171,7 +172,7 @@ public class ConstantPoolParser {
                     consumePackage(buf);
                     break;
                 default:
-                    throw new RuntimeException("Unknown constant pool type '" + tag + "'");
+                    throw new ParseException("Unknown constant pool type '" + tag + "'", ix);
             }
         }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.text.ParseException;
 import java.util.Set;
 
 import org.apache.maven.shared.dependency.analyzer.ClassFileVisitor;
@@ -95,7 +96,7 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
             // some bug inside ASM causes an IOB exception.
             // this happens when the class isn't valid.
             throw new VisitClassException("Unable to process: " + className, e);
-        } catch (IllegalArgumentException e) {
+        } catch (ParseException | IllegalArgumentException e) {
             throw new VisitClassException("Byte code of '" + className + "' is corrupt", e);
         }
     }


### PR DESCRIPTION
Previously this would result in a raw runtime exception nothing was catching.

fixes #145