### PR TITLE
Optimize artifact lookup in DefaultProjectDependencyAnalyzer

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -265,7 +265,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         for (Map.Entry<Artifact, Set<String>> entry : artifactClassMap.entrySet()) {
             Artifact artifact = entry.getKey();
             for (String className : entry.getValue()) {
-                classToArtifactMap.put(className, artifact);
+                classToArtifactMap.putIfAbsent(className, artifact);
             }
         }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -43,7 +43,9 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 
 /**
- * <p>DefaultProjectDependencyAnalyzer class.</p>
+ * <p>
+ * DefaultProjectDependencyAnalyzer class.
+ * </p>
  *
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
  */
@@ -69,6 +71,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         try {
             ClassesPatterns excludedClassesPatterns = new ClassesPatterns(excludedClasses);
             Map<Artifact, Set<String>> artifactClassMap = buildArtifactClassMap(project, excludedClassesPatterns);
+            Map<String, Artifact> classToArtifactMap = buildClassToArtifactMap(artifactClassMap);
 
             Set<DependencyUsage> mainDependencyClasses = new HashSet<>();
             for (MainDependencyClassesProvider provider : mainDependencyClassesProviders) {
@@ -84,14 +87,14 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             dependencyClasses.addAll(mainDependencyClasses);
             dependencyClasses.addAll(testDependencyClasses);
 
-            Set<DependencyUsage> testOnlyDependencyClasses =
-                    buildTestOnlyDependencyClasses(mainDependencyClasses, testDependencyClasses);
+            Set<DependencyUsage> testOnlyDependencyClasses = buildTestOnlyDependencyClasses(mainDependencyClasses,
+                    testDependencyClasses);
 
-            Map<Artifact, Set<DependencyUsage>> usedArtifacts = buildUsedArtifacts(artifactClassMap, dependencyClasses);
-            Set<Artifact> mainUsedArtifacts =
-                    buildUsedArtifacts(artifactClassMap, mainDependencyClasses).keySet();
+            Map<Artifact, Set<DependencyUsage>> usedArtifacts = buildUsedArtifacts(classToArtifactMap,
+                    dependencyClasses);
+            Set<Artifact> mainUsedArtifacts = buildUsedArtifacts(classToArtifactMap, mainDependencyClasses).keySet();
 
-            Set<Artifact> testArtifacts = buildUsedArtifacts(artifactClassMap, testOnlyDependencyClasses)
+            Set<Artifact> testArtifacts = buildUsedArtifacts(classToArtifactMap, testOnlyDependencyClasses)
                     .keySet();
             Set<Artifact> testOnlyArtifacts = removeAll(testArtifacts, mainUsedArtifacts);
 
@@ -105,8 +108,8 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             }
 
             Map<Artifact, Set<DependencyUsage>> usedUndeclaredArtifactsWithClasses = new LinkedHashMap<>(usedArtifacts);
-            Set<Artifact> usedUndeclaredArtifacts =
-                    removeAll(usedUndeclaredArtifactsWithClasses.keySet(), declaredArtifacts);
+            Set<Artifact> usedUndeclaredArtifacts = removeAll(usedUndeclaredArtifactsWithClasses.keySet(),
+                    declaredArtifacts);
 
             usedUndeclaredArtifactsWithClasses.keySet().retainAll(usedUndeclaredArtifacts);
 
@@ -124,7 +127,8 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
     }
 
     /**
-     * This method defines a new way to remove the artifacts by using the conflict id. We don't care about the version
+     * This method defines a new way to remove the artifacts by using the conflict
+     * id. We don't care about the version
      * here because there can be only 1 for a given artifact anyway.
      *
      * @param start  initial set
@@ -156,7 +160,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         Set<Artifact> nonTestScopeArtifacts = new LinkedHashSet<>();
 
         for (Artifact artifact : testOnlyArtifacts) {
-            if (artifact.getScope().equals("compile")) {
+            if (Artifact.SCOPE_COMPILE.equals(artifact.getScope())) {
                 nonTestScopeArtifacts.add(artifact);
             }
         }
@@ -226,19 +230,14 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
     }
 
     private static Map<Artifact, Set<DependencyUsage>> buildUsedArtifacts(
-            Map<Artifact, Set<String>> artifactClassMap, Set<DependencyUsage> dependencyClasses) {
+            Map<String, Artifact> classToArtifactMap, Set<DependencyUsage> dependencyClasses) {
         Map<Artifact, Set<DependencyUsage>> usedArtifacts = new HashMap<>();
 
         for (DependencyUsage classUsage : dependencyClasses) {
-            Artifact artifact = findArtifactForClassName(artifactClassMap, classUsage.getDependencyClass());
+            Artifact artifact = classToArtifactMap.get(classUsage.getDependencyClass());
 
             if (artifact != null && !includedInJDK(artifact)) {
-                Set<DependencyUsage> classesFromArtifact = usedArtifacts.get(artifact);
-                if (classesFromArtifact == null) {
-                    classesFromArtifact = new HashSet<>();
-                    usedArtifacts.put(artifact, classesFromArtifact);
-                }
-                classesFromArtifact.add(classUsage);
+                usedArtifacts.computeIfAbsent(artifact, k -> new HashSet<>()).add(classUsage);
             }
         }
 
@@ -260,13 +259,16 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return false;
     }
 
-    private static Artifact findArtifactForClassName(Map<Artifact, Set<String>> artifactClassMap, String className) {
+    private static Map<String, Artifact> buildClassToArtifactMap(Map<Artifact, Set<String>> artifactClassMap) {
+        Map<String, Artifact> classToArtifactMap = new HashMap<>();
+
         for (Map.Entry<Artifact, Set<String>> entry : artifactClassMap.entrySet()) {
-            if (entry.getValue().contains(className)) {
-                return entry.getKey();
+            Artifact artifact = entry.getKey();
+            for (String className : entry.getValue()) {
+                classToArtifactMap.put(className, artifact);
             }
         }
 
-        return null;
+        return classToArtifactMap;
     }
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -43,9 +43,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
 
 /**
- * <p>
- * DefaultProjectDependencyAnalyzer class.
- * </p>
+ * <p>DefaultProjectDependencyAnalyzer class.</p>
  *
  * @author <a href="mailto:markhobson@gmail.com">Mark Hobson</a>
  */
@@ -87,12 +85,13 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             dependencyClasses.addAll(mainDependencyClasses);
             dependencyClasses.addAll(testDependencyClasses);
 
-            Set<DependencyUsage> testOnlyDependencyClasses = buildTestOnlyDependencyClasses(mainDependencyClasses,
-                    testDependencyClasses);
+            Set<DependencyUsage> testOnlyDependencyClasses =
+                    buildTestOnlyDependencyClasses(mainDependencyClasses, testDependencyClasses);
 
-            Map<Artifact, Set<DependencyUsage>> usedArtifacts = buildUsedArtifacts(classToArtifactMap,
-                    dependencyClasses);
-            Set<Artifact> mainUsedArtifacts = buildUsedArtifacts(classToArtifactMap, mainDependencyClasses).keySet();
+            Map<Artifact, Set<DependencyUsage>> usedArtifacts =
+                    buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+            Set<Artifact> mainUsedArtifacts = buildUsedArtifacts(classToArtifactMap, mainDependencyClasses)
+                    .keySet();
 
             Set<Artifact> testArtifacts = buildUsedArtifacts(classToArtifactMap, testOnlyDependencyClasses)
                     .keySet();
@@ -108,8 +107,8 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             }
 
             Map<Artifact, Set<DependencyUsage>> usedUndeclaredArtifactsWithClasses = new LinkedHashMap<>(usedArtifacts);
-            Set<Artifact> usedUndeclaredArtifacts = removeAll(usedUndeclaredArtifactsWithClasses.keySet(),
-                    declaredArtifacts);
+            Set<Artifact> usedUndeclaredArtifacts =
+                    removeAll(usedUndeclaredArtifactsWithClasses.keySet(), declaredArtifacts);
 
             usedUndeclaredArtifactsWithClasses.keySet().retainAll(usedUndeclaredArtifacts);
 
@@ -229,7 +228,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return declaredArtifacts;
     }
 
-    private static Map<Artifact, Set<DependencyUsage>> buildUsedArtifacts(
+    static Map<Artifact, Set<DependencyUsage>> buildUsedArtifacts(
             Map<String, Artifact> classToArtifactMap, Set<DependencyUsage> dependencyClasses) {
         Map<Artifact, Set<DependencyUsage>> usedArtifacts = new HashMap<>();
 
@@ -246,7 +245,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
 
     // MSHARED-47 an uncommon case where a commonly used
     // third party dependency was added to the JDK
-    private static boolean includedInJDK(Artifact artifact) {
+    static boolean includedInJDK(Artifact artifact) {
         if ("xml-apis".equals(artifact.getGroupId())) {
             if ("xml-apis".equals(artifact.getArtifactId())) {
                 return true;
@@ -259,7 +258,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return false;
     }
 
-    private static Map<String, Artifact> buildClassToArtifactMap(Map<Artifact, Set<String>> artifactClassMap) {
+    static Map<String, Artifact> buildClassToArtifactMap(Map<Artifact, Set<String>> artifactClassMap) {
         Map<String, Artifact> classToArtifactMap = new HashMap<>();
 
         for (Map.Entry<Artifact, Set<String>> entry : artifactClassMap.entrySet()) {

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -18,12 +18,12 @@
  */
 package org.apache.maven.shared.dependency.analyzer;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.HashSet;
-import java.util.Arrays;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
@@ -91,7 +91,8 @@ class DefaultProjectDependencyAnalyzerTest {
         Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
         Set<DependencyUsage> dependencyClasses = Collections.singleton(new DependencyUsage("class1", "main"));
 
-        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+        Map<Artifact, Set<DependencyUsage>> result =
+                DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(artifact1)).hasSize(1);
@@ -102,12 +103,11 @@ class DefaultProjectDependencyAnalyzerTest {
     void testBuildUsedArtifactsWithMultipleClasses() {
         Artifact artifact1 = aTestArtifact("artifact1");
         Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
-        Set<DependencyUsage> dependencyClasses = new HashSet<>(Arrays.asList(
-                new DependencyUsage("class1", "main"),
-                new DependencyUsage("class1", "test")
-        ));
+        Set<DependencyUsage> dependencyClasses = new HashSet<>(
+                Arrays.asList(new DependencyUsage("class1", "main"), new DependencyUsage("class1", "test")));
 
-        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+        Map<Artifact, Set<DependencyUsage>> result =
+                DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(artifact1)).hasSize(2);
@@ -119,7 +119,8 @@ class DefaultProjectDependencyAnalyzerTest {
         Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
         Set<DependencyUsage> dependencyClasses = Collections.singleton(new DependencyUsage("class1", "main"));
 
-        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+        Map<Artifact, Set<DependencyUsage>> result =
+                DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
 
         // Being in JDK, it should be excluded from used artifacts
         assertThat(result).isEmpty();
@@ -127,9 +128,12 @@ class DefaultProjectDependencyAnalyzerTest {
 
     @Test
     void testIncludedInJDK() {
-        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xml-apis", "xml-apis"))).isTrue();
-        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xerces", "xmlParserAPIs"))).isTrue();
-        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("groupId", "artifactId"))).isFalse();
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xml-apis", "xml-apis")))
+                .isTrue();
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xerces", "xmlParserAPIs")))
+                .isTrue();
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("groupId", "artifactId")))
+                .isFalse();
     }
 
     private Artifact aTestArtifact(String artifactId) {

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.dependency.analyzer;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests <code>DefaultProjectDependencyAnalyzer</code>.
+ *
+ * @see DefaultProjectDependencyAnalyzer
+ */
+class DefaultProjectDependencyAnalyzerTest {
+
+    @Test
+    void testBuildClassToArtifactMap() {
+        Artifact artifact1 = aTestArtifact("artifact1");
+        Artifact artifact2 = aTestArtifact("artifact2");
+
+        Map<Artifact, Set<String>> artifactClassMap = new LinkedHashMap<>();
+        artifactClassMap.put(artifact1, Collections.singleton("class1"));
+        artifactClassMap.put(artifact2, Collections.singleton("class2"));
+
+        Map<String, Artifact> result = DefaultProjectDependencyAnalyzer.buildClassToArtifactMap(artifactClassMap);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get("class1")).isEqualTo(artifact1);
+        assertThat(result.get("class2")).isEqualTo(artifact2);
+    }
+
+    @Test
+    void testBuildClassToArtifactMapWithDuplicates() {
+        Artifact artifact1 = aTestArtifact("artifact1");
+        Artifact artifact2 = aTestArtifact("artifact2");
+
+        Map<Artifact, Set<String>> artifactClassMap = new LinkedHashMap<>();
+        artifactClassMap.put(artifact1, Collections.singleton("duplicateClass"));
+        artifactClassMap.put(artifact2, Collections.singleton("duplicateClass"));
+
+        Map<String, Artifact> result = DefaultProjectDependencyAnalyzer.buildClassToArtifactMap(artifactClassMap);
+
+        assertThat(result).hasSize(1);
+        // Should favor the first artifact encountered
+        assertThat(result.get("duplicateClass")).isEqualTo(artifact1);
+    }
+
+    @Test
+    void testBuildClassToArtifactMapWithMultipleClasses() {
+        Artifact artifact1 = aTestArtifact("artifact1");
+
+        Map<Artifact, Set<String>> artifactClassMap = new LinkedHashMap<>();
+        artifactClassMap.put(artifact1, new HashSet<>(Arrays.asList("class1", "class2")));
+
+        Map<String, Artifact> result = DefaultProjectDependencyAnalyzer.buildClassToArtifactMap(artifactClassMap);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get("class1")).isEqualTo(artifact1);
+        assertThat(result.get("class2")).isEqualTo(artifact1);
+    }
+
+    @Test
+    void testBuildUsedArtifacts() {
+        Artifact artifact1 = aTestArtifact("artifact1");
+        Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
+        Set<DependencyUsage> dependencyClasses = Collections.singleton(new DependencyUsage("class1", "main"));
+
+        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(artifact1)).hasSize(1);
+        assertThat(result.get(artifact1).iterator().next().getDependencyClass()).isEqualTo("class1");
+    }
+
+    @Test
+    void testBuildUsedArtifactsWithMultipleClasses() {
+        Artifact artifact1 = aTestArtifact("artifact1");
+        Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
+        Set<DependencyUsage> dependencyClasses = new HashSet<>(Arrays.asList(
+                new DependencyUsage("class1", "main"),
+                new DependencyUsage("class1", "test")
+        ));
+
+        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(artifact1)).hasSize(2);
+    }
+
+    @Test
+    void testBuildUsedArtifactsWithJDKExcluded() {
+        Artifact artifact1 = aTestArtifact("xml-apis", "xml-apis");
+        Map<String, Artifact> classToArtifactMap = Collections.singletonMap("class1", artifact1);
+        Set<DependencyUsage> dependencyClasses = Collections.singleton(new DependencyUsage("class1", "main"));
+
+        Map<Artifact, Set<DependencyUsage>> result = DefaultProjectDependencyAnalyzer.buildUsedArtifacts(classToArtifactMap, dependencyClasses);
+
+        // Being in JDK, it should be excluded from used artifacts
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void testIncludedInJDK() {
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xml-apis", "xml-apis"))).isTrue();
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("xerces", "xmlParserAPIs"))).isTrue();
+        assertThat(DefaultProjectDependencyAnalyzer.includedInJDK(aTestArtifact("groupId", "artifactId"))).isFalse();
+    }
+
+    private Artifact aTestArtifact(String artifactId) {
+        return aTestArtifact("groupId", artifactId);
+    }
+
+    private Artifact aTestArtifact(String groupId, String artifactId) {
+        return new DefaultArtifact(
+                groupId, artifactId, VersionRange.createFromVersion("1.0"), "compile", "jar", "", null);
+    }
+}


### PR DESCRIPTION
While reviewing the core analysis logic, I noticed a performance bottleneck in `DefaultProjectDependencyAnalyzer`. \n\nPreviously, it used a linear search to find which artifact a class belongs to ($O(N)$ for every class usage), which could be a bottleneck in large projects with many dependencies. These changes switch to a `Map`-based lookup ($O(1)$) and modernize the code using `computeIfAbsent` and more robust scope checks.\n\nThis significantly improves the efficiency of the analysis process for projects with large dependency trees.