### PR TITLE
Fix inner class types in generic signature visitor

### DIFF
--- a/src/it/genericInnerClassDependency/consumer/pom.xml
+++ b/src/it/genericInnerClassDependency/consumer/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>example</groupId>
+    <artifactId>root</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>consumer</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>example</groupId>
+      <artifactId>library</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/genericInnerClassDependency/consumer/src/main/java/consumer/Consumer.java
+++ b/src/it/genericInnerClassDependency/consumer/src/main/java/consumer/Consumer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package consumer;
+
+import java.util.function.Supplier;
+
+import library.Holder;
+
+public class Consumer implements Supplier<Holder.Entry<String, String>> {
+    @Override
+    public Holder.Entry<String, String> get() {
+        return null;
+    }
+}

--- a/src/it/genericInnerClassDependency/library/pom.xml
+++ b/src/it/genericInnerClassDependency/library/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>example</groupId>
+    <artifactId>root</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>library</artifactId>
+</project>

--- a/src/it/genericInnerClassDependency/library/src/main/java/library/Holder.java
+++ b/src/it/genericInnerClassDependency/library/src/main/java/library/Holder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package library;
+
+public class Holder<K, V> {
+    public static class Entry<K, V> {
+        private K key;
+        private V value;
+    }
+}

--- a/src/it/genericInnerClassDependency/pom.xml
+++ b/src/it/genericInnerClassDependency/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>root</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <modules>
+    <module>consumer</module>
+    <module>library</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/genericInnerClassDependency/verify.groovy
+++ b/src/it/genericInnerClassDependency/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
+
+def expected = '''
+UsedDeclaredArtifacts:
+ example:library:jar:0.0.1-SNAPSHOT:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert analysis == expected

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
@@ -18,6 +18,9 @@
  */
 package org.apache.maven.shared.dependency.analyzer.asm;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.signature.SignatureVisitor;
 
@@ -30,6 +33,7 @@ import org.objectweb.asm.signature.SignatureVisitor;
 public class DefaultSignatureVisitor extends SignatureVisitor {
     private final ResultCollector resultCollector;
     private final String usedByClass;
+    private final Deque<String> outerClasses = new ArrayDeque<>();
 
     /**
      * <p>Constructor for DefaultSignatureVisitor.</p>
@@ -45,12 +49,14 @@ public class DefaultSignatureVisitor extends SignatureVisitor {
     /** {@inheritDoc} */
     @Override
     public void visitClassType(final String name) {
+        outerClasses.push(name);
         resultCollector.addName(usedByClass, name);
     }
 
     /** {@inheritDoc} */
     @Override
     public void visitInnerClassType(final String name) {
-        resultCollector.addName(usedByClass, name);
+        String outer = outerClasses.peek();
+        resultCollector.addName(usedByClass, outer + '$' + name);
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
@@ -126,6 +126,20 @@ class DependencyVisitorTest {
     }
 
     @Test
+    void testVisitWithGenericInnerClassInterface() {
+        // class a.b.c implements p.q.r<x.y.z$Inner<a.b.c>>
+        // The generic signature uses . for inner class: x.y.z.Inner
+        // visitInnerClassType("Inner") must NOT record just "Inner" as a dependency
+        // Inner class deps are handled via outer class (ResultCollector filters $ names)
+        String signature = "Ljava/lang/Object;Lp/q/r<Lx/y/z.Inner<La/b/c;>;>;";
+
+        visitor.visit(50, 0, "a/b/c", signature, "java/lang/Object", new String[] {"p.q.r"});
+
+        assertThat(resultCollector.getDependencies()).contains("x.y.z");
+        assertThat(resultCollector.getDependencies()).doesNotContain("Inner");
+    }
+
+    @Test
     void testVisitWithInterfaceBound() {
         // class a.b.c<T> implements x.y.z<T>
         String signature = "<T:Ljava/lang/Object;>Ljava/lang/Object;Lx/y/z<TT;>;";


### PR DESCRIPTION
Fixes #282

DefaultSignatureVisitor.visitInnerClassType() was recording only the inner class simple name (e.g. 'Entry') instead of the fully qualified inner class name (e.g. 'x.y.z$Inner').

This caused all inner classes referenced through generic type signatures (e.g. Map.Entry, Holder.Entry) to be silently dropped from dependency tracking.

Changes:
- Track outer class context with a Deque in DefaultSignatureVisitor
- Prepend the outer class name when visiting inner class types
- Add unit test for generic inner class interface signatures
- Add integration test with Supplier<Holder.Entry<...>>