### PR TITLE
Record method handle owner class in invokedynamic

### DIFF
--- a/src/it/methodHandleDependency/consumer/pom.xml
+++ b/src/it/methodHandleDependency/consumer/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>example</groupId>
+    <artifactId>root</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>consumer</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>example</groupId>
+      <artifactId>library</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/methodHandleDependency/consumer/src/main/java/consumer/Consumer.java
+++ b/src/it/methodHandleDependency/consumer/src/main/java/consumer/Consumer.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package consumer;
+
+import java.util.function.Function;
+import library.Helper;
+
+public class Consumer {
+    public Function<String, String> getTransformer() {
+        return Helper::transform;
+    }
+}

--- a/src/it/methodHandleDependency/library/pom.xml
+++ b/src/it/methodHandleDependency/library/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>example</groupId>
+    <artifactId>root</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>library</artifactId>
+</project>

--- a/src/it/methodHandleDependency/library/src/main/java/library/Helper.java
+++ b/src/it/methodHandleDependency/library/src/main/java/library/Helper.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package library;
+
+import java.util.function.Function;
+
+public class Helper {
+    public static String transform(String input) {
+        return input.toUpperCase();
+    }
+}

--- a/src/it/methodHandleDependency/pom.xml
+++ b/src/it/methodHandleDependency/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>root</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+  <modules>
+    <module>consumer</module>
+    <module>library</module>
+  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/methodHandleDependency/verify.groovy
+++ b/src/it/methodHandleDependency/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
+
+def expected = '''
+UsedDeclaredArtifacts:
+ example:library:jar:0.0.1-SNAPSHOT:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert analysis == expected

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultMethodVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultMethodVisitor.java
@@ -172,9 +172,16 @@ public class DefaultMethodVisitor extends MethodVisitor {
     @Override
     public void visitInvokeDynamicInsn(
             String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+        if (bootstrapMethodHandle != null) {
+            resultCollector.addName(usedByClass, bootstrapMethodHandle.getOwner());
+        }
         Arrays.stream(bootstrapMethodArguments)
                 .filter(Type.class::isInstance)
                 .map(Type.class::cast)
                 .forEach(t -> resultCollector.addType(usedByClass, t));
+        Arrays.stream(bootstrapMethodArguments)
+                .filter(Handle.class::isInstance)
+                .map(Handle.class::cast)
+                .forEach(h -> resultCollector.addName(usedByClass, h.getOwner()));
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyVisitorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
@@ -686,6 +687,26 @@ class DependencyVisitorTest {
         Type type = Type.getType("(La/b/C;)V");
         mv.visitInvokeDynamicInsn("a", "", null, type);
         assertThat(resultCollector.getDependencies()).contains("a.b.C");
+    }
+
+    @Test
+    void testVisitInvokeDynamicWithHandle() {
+        Handle handle = new Handle(Opcodes.H_INVOKESTATIC, "x/y/z", "method", "()V", false);
+        mv.visitInvokeDynamicInsn("a", "()V", handle);
+        assertThat(resultCollector.getDependencies()).contains("x.y.z");
+    }
+
+    @Test
+    void testVisitInvokeDynamicWithMethodHandleInBootstrapArgs() {
+        Handle bootstrapHandle = new Handle(
+                Opcodes.H_INVOKESTATIC,
+                "java/lang/invoke/LambdaMetafactory",
+                "metafactory",
+                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;)Ljava/lang/invoke/CallSite;",
+                false);
+        Handle targetHandle = new Handle(Opcodes.H_INVOKESTATIC, "x/y/z", "method", "(Ljava/lang/String;)V", false);
+        mv.visitInvokeDynamicInsn("a", "(Ljava/lang/String;)V", bootstrapHandle, targetHandle);
+        assertThat(resultCollector.getDependencies()).contains("x.y.z");
     }
 
     private void assertVisitor(Object actualVisitor) {


### PR DESCRIPTION
Fixes #283

DefaultMethodVisitor.visitInvokeDynamicInsn() was only processing Type-typed bootstrap arguments, ignoring Handle arguments. Each Handle.getOwner() contains the owning class of the target method or field.

For method references like `CustomClass::method`, the method handle's owner class was never recorded as a dependency, causing false negatives.

Changes:
- Record `bootstrapMethodHandle.getOwner()` in addition to existing Type processing
- Also process Handle-typed bootstrap arguments (e.g. lambda method references)
- Add unit tests for invokedynamic with method handles
- Add integration test with `Helper::transform` method reference