### PR TITLE
Parse namespace-less web.xml in WarMainDependencyClassesProvider

### DIFF
--- a/src/it/warWithoutNamespace/pom.xml
+++ b/src/it/warWithoutNamespace/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>warWithoutNamespace</artifactId>
+  <version>1.0</version>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.9.12</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model-builder</artifactId>
+      <version>3.9.12</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/warWithoutNamespace/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/warWithoutNamespace/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!-- Namespace-less web.xml for Servlet 2.4 and earlier compatibility -->
+<web-app>
+
+  <filter>
+    <filter-name>model-filter</filter-name>
+    <filter-class>org.apache.maven.model.Plugin</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>model-filter</filter-name>
+    <url-pattern>/</url-pattern>
+  </filter-mapping>
+
+  <listener>
+    <listener-class>org.apache.maven.project.MavenProject</listener-class>
+  </listener>
+
+  <servlet>
+    <servlet-name>builder-servlet</servlet-name>
+    <servlet-class>org.apache.maven.model.building.DefaultModelBuilder</servlet-class>
+  </servlet>
+
+</web-app>

--- a/src/it/warWithoutNamespace/verify.groovy
+++ b/src/it/warWithoutNamespace/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def analysis = new File( basedir, 'target/analysis.txt' ).text
+
+def expected = '''
+UsedDeclaredArtifacts:
+ org.apache.maven:maven-core:jar:3.9.12:compile
+ org.apache.maven:maven-model:jar:3.9.12:compile
+ org.apache.maven:maven-model-builder:jar:3.9.12:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert analysis == expected

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/dependencyclasses/WarMainDependencyClassesProvider.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/dependencyclasses/WarMainDependencyClassesProvider.java
@@ -155,5 +155,15 @@ class WarMainDependencyClassesProvider implements MainDependencyClassesProvider 
                 return;
             }
         }
+
+        // Fallback for namespace-less web.xml (e.g. Servlet 2.4 and earlier)
+        NodeList tags = doc.getElementsByTagName(tagName);
+        for (int i = 0; i < tags.getLength(); i++) {
+            Node node = tags.item(i);
+            Optional.ofNullable(node.getTextContent())
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .ifPresent(classes::add);
+        }
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/dependencyclasses/WarMainDependencyClassesProviderTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/dependencyclasses/WarMainDependencyClassesProviderTest.java
@@ -81,7 +81,9 @@ class WarMainDependencyClassesProviderTest {
     public static Stream<Arguments> examplesData() {
         return Stream.of(
                 Arguments.of("empty-web.xml", new String[] {}),
-                Arguments.of("nons-web.xml", new String[] {}),
+                Arguments.of("nons-web.xml", new String[] {
+                    "org.example.test.Filter", "org.example.test.Listener", "org.example.test.Servlet"
+                }),
                 Arguments.of("multi-web-2.5.xml", new String[] {
                     "org.example.test.Filter1",
                     "org.example.test.Filter2",


### PR DESCRIPTION
Fixes #284

WarMainDependencyClassesProvider.processClassesFromTags() only checked three specific XML namespaces (Jakarta EE, Java EE 7-8, Java EE 5-6). web.xml files without a namespace (Servlet 2.4 and earlier) or with unknown namespaces produced zero matches, silently dropping all servlet/filter/listener class extraction.

Changes:
- Add fallback to `getElementsByTagName()` (non-namespace-aware query) when namespace queries yield no results
- Update unit test to expect classes from namespace-less web.xml
- Add integration test with namespace-less web.xml referencing servlet/filter/listener classes