### PR TITLE
MSHARED-1333 Remove dead visitInnerClassType override

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
@@ -48,9 +48,4 @@ public class DefaultSignatureVisitor extends SignatureVisitor {
         resultCollector.addName(usedByClass, name);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public void visitInnerClassType(final String name) {
-        resultCollector.addName(usedByClass, name);
-    }
 }


### PR DESCRIPTION
The `visitInnerClassType` override in `DefaultSignatureVisitor` is dead code — it records only the bare inner class name (e.g. "Inner") which is nonsensical, but it's never called in practice.

Modern `javac` always uses `$` notation in class signatures (e.g. `Lx/y/z$Inner;`) rather than dot notation (`Lx/y/z.Inner;`). ASM's `SignatureReader` treats the entire `x/y/z$Inner` as a single `visitClassType` call, so `visitInnerClassType` is never invoked for real-world class files.