### PR TITLE
Account for non-test transitive dependency scopes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
 
   <properties>
     <mavenVersion>3.9.16</mavenVersion>
+    <resolverVersion>1.9.27</resolverVersion>
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2026-05-12T20:23:28Z</project.build.outputTimestamp>
   </properties>
@@ -91,6 +92,18 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${resolverVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${resolverVersion}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/it/jarWithRelocatedDependency/pom.xml
+++ b/src/it/jarWithRelocatedDependency/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>jarWithRelocatedDependency</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis-ant</artifactId>
+      <version>1.4</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/jarWithRelocatedDependency/verify.groovy
+++ b/src/it/jarWithRelocatedDependency/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def analysis = new File( basedir, 'target/analysis.txt' ).text
+
+def expected = '''
+UsedDeclaredArtifacts:
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+ axis:axis-ant:jar:1.4:compile
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert analysis == expected

--- a/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/pom.xml
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>jarWithTransitivelyRequiredTestDependency</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>compile-consumer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+      <artifactId>transitive-provider</artifactId>
+      <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/src/main/java/it/CompileConsumer.java
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/src/main/java/it/CompileConsumer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+public class CompileConsumer extends Provider {}

--- a/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/src/test/java/it/CompileConsumerTest.java
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/compile-consumer/src/test/java/it/CompileConsumerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+import org.junit.Test;
+
+public class CompileConsumerTest {
+    @Test
+    public void test() {}
+}

--- a/src/it/jarWithTransitivelyRequiredTestDependency/pom.xml
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>jarWithTransitivelyRequiredTestDependency</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>provider</module>
+    <module>compile-consumer</module>
+    <module>runtime-consumer</module>
+  </modules>
+</project>

--- a/src/it/jarWithTransitivelyRequiredTestDependency/provider/pom.xml
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/provider/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>jarWithTransitivelyRequiredTestDependency</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>transitive-provider</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/jarWithTransitivelyRequiredTestDependency/provider/src/main/java/it/Provider.java
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/provider/src/main/java/it/Provider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+import org.junit.rules.ExternalResource;
+
+public class Provider extends ExternalResource {}

--- a/src/it/jarWithTransitivelyRequiredTestDependency/runtime-consumer/pom.xml
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/runtime-consumer/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>jarWithTransitivelyRequiredTestDependency</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>runtime-consumer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+      <artifactId>transitive-provider</artifactId>
+      <version>1.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/jarWithTransitivelyRequiredTestDependency/runtime-consumer/src/test/java/it/RuntimeConsumerTest.java
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/runtime-consumer/src/test/java/it/RuntimeConsumerTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package it;
+
+import org.junit.Test;
+
+public class RuntimeConsumerTest {
+    @Test
+    public void test() {}
+}

--- a/src/it/jarWithTransitivelyRequiredTestDependency/verify.groovy
+++ b/src/it/jarWithTransitivelyRequiredTestDependency/verify.groovy
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def compileAnalysis = new File(basedir, 'compile-consumer/target/analysis.txt').text
+def runtimeAnalysis = new File(basedir, 'runtime-consumer/target/analysis.txt').text
+
+def expectedCompileAnalysis = '''
+UsedDeclaredArtifacts:
+ org.apache.maven.shared.dependency-analyzer.tests:transitive-provider:jar:1.0:compile
+ junit:junit:jar:4.13.2:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+
+TestArtifactsWithNonTestScope:
+'''
+
+def expectedRuntimeAnalysis = '''
+UsedDeclaredArtifacts:
+ junit:junit:jar:4.13.2:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+ org.apache.maven.shared.dependency-analyzer.tests:transitive-provider:jar:1.0:runtime
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert compileAnalysis == expectedCompileAnalysis
+assert runtimeAnalysis == expectedRuntimeAnalysis

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -25,11 +25,15 @@ import javax.inject.Singleton;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -40,7 +44,22 @@ import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
+import org.eclipse.aether.graph.DependencyFilter;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.util.artifact.ArtifactIdUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>DefaultProjectDependencyAnalyzer class.</p>
@@ -50,6 +69,10 @@ import org.apache.maven.project.MavenProject;
 @Named
 @Singleton
 public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyzer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultProjectDependencyAnalyzer.class);
+
+    private static final DependencyFilter NO_ARTIFACT_RESOLUTION = (node, parents) -> false;
+
     /**
      * ClassAnalyzer
      */
@@ -61,6 +84,16 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
 
     @Inject
     private List<TestDependencyClassesProvider> testDependencyClassesProviders;
+
+    @Inject
+    private ProjectDependenciesResolver projectDependenciesResolver;
+
+    /** Constructor used by Sisu. */
+    public DefaultProjectDependencyAnalyzer() {}
+
+    DefaultProjectDependencyAnalyzer(ProjectDependenciesResolver projectDependenciesResolver) {
+        this.projectDependenciesResolver = projectDependenciesResolver;
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -115,7 +148,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             Set<Artifact> unusedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
             unusedDeclaredArtifacts = removeAll(unusedDeclaredArtifacts, usedArtifacts.keySet());
 
-            Set<Artifact> testArtifactsWithNonTestScope = getTestArtifactsWithNonTestScope(testOnlyArtifacts);
+            Set<Artifact> testArtifactsWithNonTestScope = getTestArtifactsWithNonTestScope(project, testOnlyArtifacts);
 
             return new ProjectDependencyAnalysis(
                     usedDeclaredArtifactsWithClasses, usedUndeclaredArtifactsWithClasses,
@@ -155,7 +188,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return results;
     }
 
-    private static Set<Artifact> getTestArtifactsWithNonTestScope(Set<Artifact> testOnlyArtifacts) {
+    Set<Artifact> getTestArtifactsWithNonTestScope(MavenProject project, Set<Artifact> testOnlyArtifacts) {
         Set<Artifact> nonTestScopeArtifacts = new LinkedHashSet<>();
 
         for (Artifact artifact : testOnlyArtifacts) {
@@ -164,7 +197,142 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             }
         }
 
+        if (nonTestScopeArtifacts.isEmpty()) {
+            return nonTestScopeArtifacts;
+        }
+
+        ProjectBuildingRequest projectBuildingRequest = project.getProjectBuildingRequest();
+        RepositorySystemSession repositorySession =
+                projectBuildingRequest != null ? projectBuildingRequest.getRepositorySession() : null;
+        if (repositorySession == null) {
+            LOGGER.debug("Cannot refine test-only dependency scopes without a repository session");
+            return nonTestScopeArtifacts;
+        }
+
+        try {
+            // Resolve each non-test classpath independently and without the candidates as direct roots. Otherwise a
+            // direct declaration can hide the same artifact reached transitively with a different scope.
+            Set<String> nonTestDependencyIds = collectDependencyIds(
+                    createDependencyGraphProject(
+                            project, nonTestScopeArtifacts, NonTestClasspath.COMPILE, repositorySession),
+                    repositorySession);
+            nonTestDependencyIds.addAll(collectDependencyIds(
+                    createDependencyGraphProject(
+                            project, nonTestScopeArtifacts, NonTestClasspath.RUNTIME, repositorySession),
+                    repositorySession));
+
+            nonTestScopeArtifacts.removeIf(artifact -> nonTestDependencyIds.contains(toVersionlessId(artifact)));
+        } catch (DependencyResolutionException exception) {
+            LOGGER.debug("Cannot refine test-only dependency scopes using the non-test dependency graphs", exception);
+        }
+
         return nonTestScopeArtifacts;
+    }
+
+    private Set<String> collectDependencyIds(MavenProject project, RepositorySystemSession repositorySession)
+            throws DependencyResolutionException {
+        DependencyResolutionRequest request = new DefaultDependencyResolutionRequest(project, repositorySession);
+        request.setResolutionFilter(NO_ARTIFACT_RESOLUTION);
+        DependencyResolutionResult result = projectDependenciesResolver.resolve(request);
+
+        Set<String> dependencyIds = new HashSet<>();
+        DependencyNode root = result.getDependencyGraph();
+        if (root == null) {
+            return dependencyIds;
+        }
+
+        Deque<DependencyNode> remaining = new ArrayDeque<>(root.getChildren());
+        Set<DependencyNode> visited = Collections.newSetFromMap(new IdentityHashMap<DependencyNode, Boolean>());
+        while (!remaining.isEmpty()) {
+            DependencyNode node = remaining.removeFirst();
+            if (visited.add(node)) {
+                if (node.getArtifact() != null) {
+                    dependencyIds.add(ArtifactIdUtils.toVersionlessId(node.getArtifact()));
+                }
+                remaining.addAll(node.getChildren());
+            }
+        }
+        return dependencyIds;
+    }
+
+    private static MavenProject createDependencyGraphProject(
+            MavenProject project,
+            Set<Artifact> candidates,
+            NonTestClasspath classpath,
+            RepositorySystemSession repositorySession) {
+        MavenProject graphProject = new MavenProject(project);
+        Set<String> candidateIds =
+                candidates.stream().map(Artifact::getDependencyConflictId).collect(Collectors.toSet());
+
+        Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
+        if (dependencyArtifacts == null) {
+            ArtifactTypeRegistry stereotypes = repositorySession.getArtifactTypeRegistry();
+            List<Dependency> dependencies = project.getDependencies().stream()
+                    .filter(dependency -> classpath.includes(dependency.getScope()))
+                    .filter(dependency -> !candidateIds.contains(toDependencyConflictId(dependency, stereotypes)))
+                    .collect(Collectors.toList());
+            graphProject.setDependencies(dependencies);
+            graphProject.setDependencyArtifacts(null);
+        } else {
+            Set<Artifact> selectedArtifacts = dependencyArtifacts.stream()
+                    .filter(artifact -> classpath.includes(artifact.getScope()))
+                    .filter(artifact -> !candidateIds.contains(artifact.getDependencyConflictId()))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            Set<String> selectedIds = selectedArtifacts.stream()
+                    .map(Artifact::getDependencyConflictId)
+                    .collect(Collectors.toSet());
+            ArtifactTypeRegistry stereotypes = repositorySession.getArtifactTypeRegistry();
+            List<Dependency> selectedDependencies = project.getDependencies().stream()
+                    .filter(dependency -> selectedIds.contains(toDependencyConflictId(dependency, stereotypes)))
+                    .collect(Collectors.toCollection(ArrayList::new));
+            graphProject.setDependencies(selectedDependencies);
+            graphProject.setDependencyArtifacts(selectedArtifacts);
+        }
+        return graphProject;
+    }
+
+    private static String toDependencyConflictId(Dependency dependency, ArtifactTypeRegistry stereotypes) {
+        String classifier = dependency.getClassifier();
+        if (classifier == null && stereotypes != null) {
+            ArtifactType type = stereotypes.get(dependency.getType());
+            if (type != null) {
+                classifier = type.getClassifier();
+            }
+        }
+        return ArtifactIdUtils.toVersionlessId(
+                dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), classifier);
+    }
+
+    private static String toVersionlessId(Artifact artifact) {
+        String extension = artifact.getArtifactHandler() != null
+                ? artifact.getArtifactHandler().getExtension()
+                : artifact.getType();
+        return ArtifactIdUtils.toVersionlessId(
+                artifact.getGroupId(), artifact.getArtifactId(), extension, artifact.getClassifier());
+    }
+
+    private enum NonTestClasspath {
+        COMPILE {
+            @Override
+            boolean includes(String scope) {
+                return scope == null
+                        || scope.isEmpty()
+                        || Artifact.SCOPE_COMPILE.equals(scope)
+                        || Artifact.SCOPE_PROVIDED.equals(scope)
+                        || Artifact.SCOPE_SYSTEM.equals(scope);
+            }
+        },
+        RUNTIME {
+            @Override
+            boolean includes(String scope) {
+                return scope == null
+                        || scope.isEmpty()
+                        || Artifact.SCOPE_COMPILE.equals(scope)
+                        || Artifact.SCOPE_RUNTIME.equals(scope);
+            }
+        };
+
+        abstract boolean includes(String scope);
     }
 
     protected Map<Artifact, Set<String>> buildArtifactClassMap(MavenProject project, ClassesPatterns excludedClasses)

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -20,13 +20,13 @@ package org.apache.maven.shared.dependency.analyzer;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -39,22 +39,25 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.DefaultDependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.project.ProjectDependenciesResolver;
 import org.eclipse.aether.RepositorySystemSession;
-import org.eclipse.aether.artifact.ArtifactType;
-import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.graph.DependencyNode;
 import org.eclipse.aether.util.artifact.ArtifactIdUtils;
@@ -88,11 +91,22 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
     @Inject
     private ProjectDependenciesResolver projectDependenciesResolver;
 
+    @Inject
+    private Provider<MavenSession> mavenSessionProvider;
+
+    @Inject
+    private ArtifactHandlerManager artifactHandlerManager;
+
     /** Constructor used by Sisu. */
     public DefaultProjectDependencyAnalyzer() {}
 
-    DefaultProjectDependencyAnalyzer(ProjectDependenciesResolver projectDependenciesResolver) {
+    DefaultProjectDependencyAnalyzer(
+            ProjectDependenciesResolver projectDependenciesResolver,
+            Provider<MavenSession> mavenSessionProvider,
+            ArtifactHandlerManager artifactHandlerManager) {
         this.projectDependenciesResolver = projectDependenciesResolver;
+        this.mavenSessionProvider = mavenSessionProvider;
+        this.artifactHandlerManager = artifactHandlerManager;
     }
 
     /** {@inheritDoc} */
@@ -130,7 +144,7 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
                     .keySet();
             Set<Artifact> testOnlyArtifacts = removeAll(testArtifacts, mainUsedArtifacts);
 
-            Set<Artifact> declaredArtifacts = buildDeclaredArtifacts(project);
+            Set<Artifact> declaredArtifacts = buildDeclaredArtifacts(project, artifactHandlerManager);
             Set<Artifact> usedDeclaredArtifacts = new LinkedHashSet<>(declaredArtifacts);
             usedDeclaredArtifacts.retainAll(usedArtifacts.keySet());
 
@@ -201,24 +215,20 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
             return nonTestScopeArtifacts;
         }
 
-        ProjectBuildingRequest projectBuildingRequest = project.getProjectBuildingRequest();
-        RepositorySystemSession repositorySession =
-                projectBuildingRequest != null ? projectBuildingRequest.getRepositorySession() : null;
+        RepositorySystemSession repositorySession = getRepositorySystemSession();
         if (repositorySession == null) {
             LOGGER.debug("Cannot refine test-only dependency scopes without a repository session");
             return nonTestScopeArtifacts;
         }
 
         try {
-            // Resolve each non-test classpath independently and without the candidates as direct roots. Otherwise a
+            // Collect each non-test classpath independently and without the candidates as direct roots. Otherwise a
             // direct declaration can hide the same artifact reached transitively with a different scope.
             Set<String> nonTestDependencyIds = collectDependencyIds(
-                    createDependencyGraphProject(
-                            project, nonTestScopeArtifacts, NonTestClasspath.COMPILE, repositorySession),
+                    createDependencyGraphProject(project, nonTestScopeArtifacts, NonTestClasspath.COMPILE),
                     repositorySession);
             nonTestDependencyIds.addAll(collectDependencyIds(
-                    createDependencyGraphProject(
-                            project, nonTestScopeArtifacts, NonTestClasspath.RUNTIME, repositorySession),
+                    createDependencyGraphProject(project, nonTestScopeArtifacts, NonTestClasspath.RUNTIME),
                     repositorySession));
 
             nonTestScopeArtifacts.removeIf(artifact -> nonTestDependencyIds.contains(toVersionlessId(artifact)));
@@ -255,49 +265,30 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return dependencyIds;
     }
 
-    private static MavenProject createDependencyGraphProject(
-            MavenProject project,
-            Set<Artifact> candidates,
-            NonTestClasspath classpath,
-            RepositorySystemSession repositorySession) {
-        MavenProject graphProject = new MavenProject(project);
+    private MavenProject createDependencyGraphProject(
+            MavenProject project, Set<Artifact> candidates, NonTestClasspath classpath) {
         Set<String> candidateIds =
                 candidates.stream().map(Artifact::getDependencyConflictId).collect(Collectors.toSet());
-
-        Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
-        if (dependencyArtifacts == null) {
-            ArtifactTypeRegistry stereotypes = repositorySession.getArtifactTypeRegistry();
-            List<Dependency> dependencies = project.getDependencies().stream()
-                    .filter(dependency -> classpath.includes(dependency.getScope()))
-                    .filter(dependency -> !candidateIds.contains(toDependencyConflictId(dependency, stereotypes)))
-                    .collect(Collectors.toList());
-            graphProject.setDependencies(dependencies);
-            graphProject.setDependencyArtifacts(null);
-        } else {
-            Set<Artifact> selectedArtifacts = dependencyArtifacts.stream()
-                    .filter(artifact -> classpath.includes(artifact.getScope()))
-                    .filter(artifact -> !candidateIds.contains(artifact.getDependencyConflictId()))
-                    .collect(Collectors.toCollection(LinkedHashSet::new));
-            Set<String> selectedIds = selectedArtifacts.stream()
-                    .map(Artifact::getDependencyConflictId)
-                    .collect(Collectors.toSet());
-            ArtifactTypeRegistry stereotypes = repositorySession.getArtifactTypeRegistry();
-            List<Dependency> selectedDependencies = project.getDependencies().stream()
-                    .filter(dependency -> selectedIds.contains(toDependencyConflictId(dependency, stereotypes)))
-                    .collect(Collectors.toCollection(ArrayList::new));
-            graphProject.setDependencies(selectedDependencies);
-            graphProject.setDependencyArtifacts(selectedArtifacts);
-        }
-        return graphProject;
+        List<Dependency> dependencies = project.getDependencies().stream()
+                .filter(dependency -> classpath.includes(dependency.getScope()))
+                .filter(dependency -> !candidateIds.contains(toDependencyConflictId(dependency)))
+                .collect(Collectors.toList());
+        return new DependencyGraphProject(project, dependencies);
     }
 
-    private static String toDependencyConflictId(Dependency dependency, ArtifactTypeRegistry stereotypes) {
+    private RepositorySystemSession getRepositorySystemSession() {
+        MavenSession mavenSession = mavenSessionProvider != null ? mavenSessionProvider.get() : null;
+        return mavenSession != null ? mavenSession.getRepositorySession() : null;
+    }
+
+    private String toDependencyConflictId(Dependency dependency) {
+        return toDependencyConflictId(dependency, artifactHandlerManager.getArtifactHandler(dependency.getType()));
+    }
+
+    private static String toDependencyConflictId(Dependency dependency, ArtifactHandler artifactHandler) {
         String classifier = dependency.getClassifier();
-        if (classifier == null && stereotypes != null) {
-            ArtifactType type = stereotypes.get(dependency.getType());
-            if (type != null) {
-                classifier = type.getClassifier();
-            }
+        if (classifier == null) {
+            classifier = artifactHandler.getClassifier();
         }
         return ArtifactIdUtils.toVersionlessId(
                 dependency.getGroupId(), dependency.getArtifactId(), dependency.getType(), classifier);
@@ -386,14 +377,47 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         return testOnlyDependencyClasses;
     }
 
-    private static Set<Artifact> buildDeclaredArtifacts(MavenProject project) {
-        Set<Artifact> declaredArtifacts = project.getDependencyArtifacts();
+    static Set<Artifact> buildDeclaredArtifacts(MavenProject project, ArtifactHandlerManager artifactHandlerManager) {
+        Map<String, Artifact> resolvedArtifacts = project.getArtifacts().stream()
+                .collect(Collectors.toMap(
+                        Artifact::getDependencyConflictId,
+                        Function.identity(),
+                        (first, second) -> first,
+                        LinkedHashMap::new));
+        Set<Artifact> declaredArtifacts = new LinkedHashSet<>();
+        for (Dependency dependency : project.getDependencies()) {
+            ArtifactHandler artifactHandler = artifactHandlerManager.getArtifactHandler(dependency.getType());
+            String dependencyConflictId = toDependencyConflictId(dependency, artifactHandler);
+            Artifact artifact = resolvedArtifacts.get(dependencyConflictId);
+            if (artifact == null) {
+                artifact = new DefaultArtifact(
+                        dependency.getGroupId(),
+                        dependency.getArtifactId(),
+                        VersionRange.createFromVersion(dependency.getVersion()),
+                        dependency.getScope(),
+                        dependency.getType(),
+                        dependency.getClassifier(),
+                        artifactHandler,
+                        dependency.isOptional());
+            }
+            declaredArtifacts.add(artifact);
+        }
+        return declaredArtifacts;
+    }
 
-        if (declaredArtifacts == null) {
-            declaredArtifacts = Collections.emptySet();
+    private static final class DependencyGraphProject extends MavenProject {
+        private DependencyGraphProject(MavenProject project, List<Dependency> dependencies) {
+            super(project);
+            setDependencies(dependencies);
         }
 
-        return declaredArtifacts;
+        @Override
+        @SuppressWarnings("deprecation")
+        public Set<Artifact> getDependencyArtifacts() {
+            // Make ProjectDependenciesResolver collect the filtered model dependencies while retaining all other
+            // decorator-visible state copied by MavenProject(MavenProject).
+            return null;
+        }
     }
 
     static Map<Artifact, Set<DependencyUsage>> buildUsedArtifacts(

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -22,15 +22,35 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.versioning.VersionRange;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests <code>DefaultProjectDependencyAnalyzer</code>.
@@ -38,6 +58,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @see DefaultProjectDependencyAnalyzer
  */
 class DefaultProjectDependencyAnalyzerTest {
+    private ProjectDependenciesResolver projectDependenciesResolver;
+
+    private DefaultProjectDependencyAnalyzer analyzer;
+
+    @BeforeEach
+    void setUp() {
+        projectDependenciesResolver = mock(ProjectDependenciesResolver.class);
+        analyzer = new DefaultProjectDependencyAnalyzer(projectDependenciesResolver);
+    }
 
     @Test
     void testBuildClassToArtifactMap() {
@@ -136,12 +165,106 @@ class DefaultProjectDependencyAnalyzerTest {
                 .isFalse();
     }
 
+    @Test
+    void testRetainsTestOnlyCompileDependencyWithoutRepositorySession() {
+        Artifact candidate = aTestArtifact("candidate");
+
+        assertThat(analyzer.getTestArtifactsWithNonTestScope(new MavenProject(), Collections.singleton(candidate)))
+                .containsExactly(candidate);
+        verifyNoInteractions(projectDependenciesResolver);
+    }
+
+    @Test
+    void testRetainsTestOnlyCompileDependencyWhenRuntimeGraphCollectionFails() throws Exception {
+        Artifact candidate = aTestArtifact("candidate");
+        MavenProject project = projectWithRepositorySession(candidate);
+        DependencyResolutionResult failedResult = mock(DependencyResolutionResult.class);
+        when(failedResult.getUnresolvedDependencies()).thenReturn(Collections.emptyList());
+        when(failedResult.getCollectionErrors()).thenReturn(Collections.emptyList());
+        DependencyResolutionException failure =
+                new DependencyResolutionException(failedResult, "collection failed", new Exception("failure"));
+        DependencyResolutionResult compileResult = dependencyGraph("candidate", "2.0");
+        when(projectDependenciesResolver.resolve(any(DependencyResolutionRequest.class)))
+                .thenReturn(compileResult)
+                .thenThrow(failure);
+
+        assertThat(analyzer.getTestArtifactsWithNonTestScope(project, Collections.singleton(candidate)))
+                .containsExactly(candidate);
+    }
+
+    @Test
+    void testRemovesDependenciesReachableFromCompileOrRuntimeGraph() throws Exception {
+        Artifact compileCandidate = aTestArtifact("compile-candidate");
+        Artifact runtimeCandidate = aTestArtifact("runtime-candidate");
+        Artifact compile = aTestArtifactWithScope("compile", Artifact.SCOPE_COMPILE);
+        Artifact provided = aTestArtifactWithScope("provided", Artifact.SCOPE_PROVIDED);
+        Artifact system = aTestArtifactWithScope("system", Artifact.SCOPE_SYSTEM);
+        Artifact runtime = aTestArtifactWithScope("runtime", Artifact.SCOPE_RUNTIME);
+        Artifact test = aTestArtifactWithScope("test", Artifact.SCOPE_TEST);
+        MavenProject project = projectWithRepositorySession(
+                compileCandidate, runtimeCandidate, compile, provided, system, runtime, test);
+
+        DependencyResolutionResult compileResult = dependencyGraph("compile-candidate", "2.0");
+        DependencyResolutionResult runtimeResult = dependencyGraph("runtime-candidate", "2.0");
+        when(projectDependenciesResolver.resolve(any(DependencyResolutionRequest.class)))
+                .thenReturn(compileResult, runtimeResult);
+
+        Set<Artifact> candidates = new LinkedHashSet<>(Arrays.asList(compileCandidate, runtimeCandidate));
+        assertThat(analyzer.getTestArtifactsWithNonTestScope(project, candidates))
+                .isEmpty();
+
+        ArgumentCaptor<DependencyResolutionRequest> requestCaptor =
+                ArgumentCaptor.forClass(DependencyResolutionRequest.class);
+        verify(projectDependenciesResolver, times(2)).resolve(requestCaptor.capture());
+        List<DependencyResolutionRequest> requests = requestCaptor.getAllValues();
+        assertThat(artifactIds(requests.get(0).getMavenProject()))
+                .containsExactlyInAnyOrder("compile", "provided", "system");
+        assertThat(artifactIds(requests.get(1).getMavenProject())).containsExactlyInAnyOrder("compile", "runtime");
+        DependencyNode dependencyNode = new DefaultDependencyNode(
+                new org.eclipse.aether.artifact.DefaultArtifact("groupId", "artifactId", "jar", "1.0"));
+        assertThat(requests).allSatisfy(request -> {
+            assertThat(request.getResolutionFilter()).isNotNull();
+            assertThat(request.getResolutionFilter().accept(dependencyNode, Collections.emptyList()))
+                    .isFalse();
+        });
+    }
+
+    private MavenProject projectWithRepositorySession(Artifact... dependencyArtifacts) {
+        MavenProject project = new MavenProject();
+        project.setDependencyArtifacts(new LinkedHashSet<>(Arrays.asList(dependencyArtifacts)));
+        RepositorySystemSession repositorySession = mock(RepositorySystemSession.class);
+        project.setProjectBuildingRequest(new DefaultProjectBuildingRequest().setRepositorySession(repositorySession));
+        return project;
+    }
+
+    private DependencyResolutionResult dependencyGraph(String artifactId, String version) {
+        DependencyNode root = new DefaultDependencyNode((org.eclipse.aether.graph.Dependency) null);
+        root.setChildren(Collections.singletonList(new DefaultDependencyNode(
+                new org.eclipse.aether.artifact.DefaultArtifact("groupId", artifactId, "jar", version))));
+        DependencyResolutionResult result = mock(DependencyResolutionResult.class);
+        when(result.getDependencyGraph()).thenReturn(root);
+        return result;
+    }
+
+    private Set<String> artifactIds(MavenProject project) {
+        return project.getDependencyArtifacts().stream()
+                .map(Artifact::getArtifactId)
+                .collect(Collectors.toSet());
+    }
+
     private Artifact aTestArtifact(String artifactId) {
         return aTestArtifact("groupId", artifactId);
     }
 
     private Artifact aTestArtifact(String groupId, String artifactId) {
-        return new DefaultArtifact(
-                groupId, artifactId, VersionRange.createFromVersion("1.0"), "compile", "jar", "", null);
+        return aTestArtifact(groupId, artifactId, Artifact.SCOPE_COMPILE);
+    }
+
+    private Artifact aTestArtifactWithScope(String artifactId, String scope) {
+        return aTestArtifact("groupId", artifactId, scope);
+    }
+
+    private Artifact aTestArtifact(String groupId, String artifactId, String scope) {
+        return new DefaultArtifact(groupId, artifactId, VersionRange.createFromVersion("1.0"), scope, "jar", "", null);
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -30,8 +30,13 @@ import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.versioning.VersionRange;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Profile;
 import org.apache.maven.project.DependencyResolutionException;
 import org.apache.maven.project.DependencyResolutionRequest;
 import org.apache.maven.project.DependencyResolutionResult;
@@ -46,6 +51,7 @@ import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -60,12 +66,20 @@ import static org.mockito.Mockito.when;
 class DefaultProjectDependencyAnalyzerTest {
     private ProjectDependenciesResolver projectDependenciesResolver;
 
+    private MavenSession mavenSession;
+
+    private ArtifactHandlerManager artifactHandlerManager;
+
     private DefaultProjectDependencyAnalyzer analyzer;
 
     @BeforeEach
     void setUp() {
         projectDependenciesResolver = mock(ProjectDependenciesResolver.class);
-        analyzer = new DefaultProjectDependencyAnalyzer(projectDependenciesResolver);
+        mavenSession = mock(MavenSession.class);
+        artifactHandlerManager = mock(ArtifactHandlerManager.class);
+        when(artifactHandlerManager.getArtifactHandler(anyString())).thenReturn(mock(ArtifactHandler.class));
+        analyzer = new DefaultProjectDependencyAnalyzer(
+                projectDependenciesResolver, () -> mavenSession, artifactHandlerManager);
     }
 
     @Test
@@ -166,6 +180,64 @@ class DefaultProjectDependencyAnalyzerTest {
     }
 
     @Test
+    void testBuildDeclaredArtifactsSelectsResolvedDirectArtifacts() {
+        Artifact direct = aTestArtifact("direct");
+        Artifact transitive = aTestArtifact("transitive");
+        MavenProject project = new MavenProject();
+        project.setDependencies(Collections.singletonList(toDependency(direct)));
+        project.setArtifacts(new LinkedHashSet<>(Arrays.asList(direct, transitive)));
+
+        assertThat(DefaultProjectDependencyAnalyzer.buildDeclaredArtifacts(project, artifactHandlerManager))
+                .containsExactly(direct)
+                .first()
+                .isSameAs(direct);
+    }
+
+    @Test
+    void testBuildDeclaredArtifactsUsesDefaultClassifierFromArtifactType() {
+        Artifact testJar = new DefaultArtifact(
+                "groupId",
+                "test-jar",
+                VersionRange.createFromVersion("1.0"),
+                Artifact.SCOPE_COMPILE,
+                "test-jar",
+                "tests",
+                null);
+        Dependency dependency = toDependency(testJar);
+        dependency.setClassifier(null);
+        MavenProject project = new MavenProject();
+        project.setDependencies(Collections.singletonList(dependency));
+        project.setArtifacts(Collections.singleton(testJar));
+        ArtifactHandler testJarHandler = mock(ArtifactHandler.class);
+        when(artifactHandlerManager.getArtifactHandler("test-jar")).thenReturn(testJarHandler);
+        when(testJarHandler.getClassifier()).thenReturn("tests");
+
+        assertThat(DefaultProjectDependencyAnalyzer.buildDeclaredArtifacts(project, artifactHandlerManager))
+                .containsExactly(testJar);
+    }
+
+    @Test
+    void testBuildDeclaredArtifactsRetainsRelocatedDeclaration() {
+        Dependency declaration = new Dependency();
+        declaration.setGroupId("axis");
+        declaration.setArtifactId("axis-ant");
+        declaration.setVersion("1.4");
+        MavenProject project = new MavenProject();
+        project.setDependencies(Collections.singletonList(declaration));
+        Artifact relocated = aTestArtifact("org.apache.axis", "axis-ant");
+        project.setArtifacts(Collections.singleton(relocated));
+
+        assertThat(DefaultProjectDependencyAnalyzer.buildDeclaredArtifacts(project, artifactHandlerManager))
+                .singleElement()
+                .satisfies(artifact -> {
+                    assertThat(artifact.getGroupId()).isEqualTo("axis");
+                    assertThat(artifact.getArtifactId()).isEqualTo("axis-ant");
+                    assertThat(artifact.getVersion()).isEqualTo("1.4");
+                    assertThat(artifact).isNotSameAs(relocated);
+                });
+    }
+
+    @Test
     void testRetainsTestOnlyCompileDependencyWithoutRepositorySession() {
         Artifact candidate = aTestArtifact("candidate");
 
@@ -203,6 +275,16 @@ class DefaultProjectDependencyAnalyzerTest {
         Artifact test = aTestArtifactWithScope("test", Artifact.SCOPE_TEST);
         MavenProject project = projectWithRepositorySession(
                 compileCandidate, runtimeCandidate, compile, provided, system, runtime, test);
+        Model originalModel = new Model();
+        Profile activeProfile = new Profile();
+        activeProfile.setId("active");
+        Artifact resolvedState = aTestArtifact("resolved-state");
+        Map<String, Artifact> managedVersionMap = Collections.singletonMap("managed", aTestArtifact("managed"));
+        project.setOriginalModel(originalModel);
+        project.setActiveProfiles(Collections.singletonList(activeProfile));
+        project.setArtifacts(Collections.singleton(resolvedState));
+        project.setManagedVersionMap(managedVersionMap);
+        project.setExecutionRoot(true);
 
         DependencyResolutionResult compileResult = dependencyGraph("compile-candidate", "2.0");
         DependencyResolutionResult runtimeResult = dependencyGraph("runtime-candidate", "2.0");
@@ -223,17 +305,27 @@ class DefaultProjectDependencyAnalyzerTest {
         DependencyNode dependencyNode = new DefaultDependencyNode(
                 new org.eclipse.aether.artifact.DefaultArtifact("groupId", "artifactId", "jar", "1.0"));
         assertThat(requests).allSatisfy(request -> {
+            MavenProject graphProject = request.getMavenProject();
+            assertThat(request.getRepositorySession()).isSameAs(mavenSession.getRepositorySession());
             assertThat(request.getResolutionFilter()).isNotNull();
             assertThat(request.getResolutionFilter().accept(dependencyNode, Collections.emptyList()))
                     .isFalse();
+            assertThat(graphProject.getDependencies())
+                    .noneMatch(dependency -> dependency.getArtifactId().endsWith("candidate"));
+            assertThat(graphProject.getOriginalModel()).isSameAs(originalModel);
+            assertThat(graphProject.getActiveProfiles()).containsExactly(activeProfile);
+            assertThat(graphProject.getArtifacts()).containsExactly(resolvedState);
+            assertThat(graphProject.getManagedVersionMap()).isSameAs(managedVersionMap);
+            assertThat(graphProject.isExecutionRoot()).isTrue();
         });
     }
 
     private MavenProject projectWithRepositorySession(Artifact... dependencyArtifacts) {
         MavenProject project = new MavenProject();
-        project.setDependencyArtifacts(new LinkedHashSet<>(Arrays.asList(dependencyArtifacts)));
+        project.setDependencies(
+                Arrays.stream(dependencyArtifacts).map(this::toDependency).collect(Collectors.toList()));
         RepositorySystemSession repositorySession = mock(RepositorySystemSession.class);
-        project.setProjectBuildingRequest(new DefaultProjectBuildingRequest().setRepositorySession(repositorySession));
+        when(mavenSession.getRepositorySession()).thenReturn(repositorySession);
         return project;
     }
 
@@ -247,9 +339,18 @@ class DefaultProjectDependencyAnalyzerTest {
     }
 
     private Set<String> artifactIds(MavenProject project) {
-        return project.getDependencyArtifacts().stream()
-                .map(Artifact::getArtifactId)
-                .collect(Collectors.toSet());
+        return project.getDependencies().stream().map(Dependency::getArtifactId).collect(Collectors.toSet());
+    }
+
+    private Dependency toDependency(Artifact artifact) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(artifact.getGroupId());
+        dependency.setArtifactId(artifact.getArtifactId());
+        dependency.setVersion(artifact.getVersion());
+        dependency.setScope(artifact.getScope());
+        dependency.setType(artifact.getType());
+        dependency.setClassifier(artifact.getClassifier());
+        return dependency;
     }
 
     private Artifact aTestArtifact(String artifactId) {


### PR DESCRIPTION
## Summary

Avoid recommending `test` scope for a direct dependency when the same artifact
is still required transitively on the compile or runtime dependency graph.

The analyzer now builds separate compile and runtime graphs without the direct
test-only candidates and suppresses the warning for candidates that remain
reachable. This prevents an unsafe scope change: Maven conflict mediation can
otherwise hide the required transitive artifact behind the direct test-scoped
declaration.

Fixes apache/maven-dependency-analyzer#295

## Validation

- Maven 3.9.16 / JDK 21: `mvn -Prun-its verify`
- Maven 4 / JDK 21: `mvn clean -Prun-its verify`
- Maven 3.9.16 / JDK 8: 128 unit tests passed
- Maven Dependency Plugin downstream check: 415 unit tests passed; 102 of 103
  Invoker projects passed. The remaining project asserts the previous scope
  recommendation and passes with the unpatched analyzer. Its dependency graph
  contains the exact condition fixed here: JUnit is also reachable through
  `maven-project -> plexus-container-default`.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
