### PR TITLE
Preserve exact dependency class names containing dollar signs

### DIFF
--- a/src/it/kotlinInnerClassReference/consumer/pom.xml
+++ b/src/it/kotlinInnerClassReference/consumer/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>kotlin-inner-class-reference</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>kotlin-consumer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+      <artifactId>nested-class-library</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>1.7.21</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>1.7.21</version>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>kotlin-sources</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/main/kotlin</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+        <artifactId>maven-mock-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>mock-analyze</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/kotlinInnerClassReference/consumer/src/main/kotlin/consumer/Example.kt
+++ b/src/it/kotlinInnerClassReference/consumer/src/main/kotlin/consumer/Example.kt
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package consumer
+
+import library.Outer
+
+class Example {
+    fun createInner() {
+        Outer.Inner()
+    }
+}

--- a/src/it/kotlinInnerClassReference/library/pom.xml
+++ b/src/it/kotlinInnerClassReference/library/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>kotlin-inner-class-reference</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>nested-class-library</artifactId>
+</project>

--- a/src/it/kotlinInnerClassReference/library/src/main/java/library/Outer.java
+++ b/src/it/kotlinInnerClassReference/library/src/main/java/library/Outer.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package library;
+
+public class Outer {
+    public static class Inner {}
+}

--- a/src/it/kotlinInnerClassReference/pom.xml
+++ b/src/it/kotlinInnerClassReference/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>kotlin-inner-class-reference</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>library</module>
+    <module>consumer</module>
+  </modules>
+</project>

--- a/src/it/kotlinInnerClassReference/verify.groovy
+++ b/src/it/kotlinInnerClassReference/verify.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
+
+def expected = '''
+UsedDeclaredArtifacts:
+ org.apache.maven.shared.dependency-analyzer.tests:nested-class-library:jar:1.0:compile
+ org.jetbrains.kotlin:kotlin-stdlib:jar:1.7.21:compile
+
+UsedUndeclaredArtifactsWithClasses:
+
+UnusedDeclaredArtifacts:
+
+TestArtifactsWithNonTestScope:
+'''
+
+assert analysis == expected

--- a/src/it/topLevelDollarClassReference/consumer/pom.xml
+++ b/src/it/topLevelDollarClassReference/consumer/pom.xml
@@ -26,64 +26,22 @@
 
   <parent>
     <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
-    <artifactId>kotlin-inner-class-reference</artifactId>
+    <artifactId>top-level-dollar-class-reference</artifactId>
     <version>1.0</version>
   </parent>
 
-  <artifactId>kotlin-consumer</artifactId>
-
-  <properties>
-    <kotlin.version>2.4.10</kotlin.version>
-    <kotlin.compiler.daemon>false</kotlin.compiler.daemon>
-  </properties>
+  <artifactId>dollar-class-consumer</artifactId>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
-      <artifactId>nested-class-library</artifactId>
+      <artifactId>dollar-class-library</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-stdlib</artifactId>
-      <version>${kotlin.version}</version>
     </dependency>
   </dependencies>
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.jetbrains.kotlin</groupId>
-        <artifactId>kotlin-maven-plugin</artifactId>
-        <version>${kotlin.version}</version>
-        <executions>
-          <execution>
-            <id>compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.3.0</version>
-        <executions>
-          <execution>
-            <id>kotlin-sources</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/main/kotlin</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
         <artifactId>maven-mock-plugin</artifactId>

--- a/src/it/topLevelDollarClassReference/consumer/src/main/java/consumer/Example.java
+++ b/src/it/topLevelDollarClassReference/consumer/src/main/java/consumer/Example.java
@@ -16,19 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package consumer;
 
-def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
+import library.Dollar$Class;
 
-def expected = '''
-UsedDeclaredArtifacts:
- org.apache.maven.shared.dependency-analyzer.tests:nested-class-library:jar:1.0:compile
- org.jetbrains.kotlin:kotlin-stdlib:jar:2.4.10:compile
-
-UsedUndeclaredArtifactsWithClasses:
-
-UnusedDeclaredArtifacts:
-
-TestArtifactsWithNonTestScope:
-'''
-
-assert analysis == expected
+public class Example {
+    public Dollar$Class create() {
+        return new Dollar$Class();
+    }
+}

--- a/src/it/topLevelDollarClassReference/library/pom.xml
+++ b/src/it/topLevelDollarClassReference/library/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+    <artifactId>top-level-dollar-class-reference</artifactId>
+    <version>1.0</version>
+  </parent>
+
+  <artifactId>dollar-class-library</artifactId>
+</project>

--- a/src/it/topLevelDollarClassReference/library/src/main/java/library/Dollar$Class.java
+++ b/src/it/topLevelDollarClassReference/library/src/main/java/library/Dollar$Class.java
@@ -16,19 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package library;
 
-def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
-
-def expected = '''
-UsedDeclaredArtifacts:
- org.apache.maven.shared.dependency-analyzer.tests:nested-class-library:jar:1.0:compile
- org.jetbrains.kotlin:kotlin-stdlib:jar:2.4.10:compile
-
-UsedUndeclaredArtifactsWithClasses:
-
-UnusedDeclaredArtifacts:
-
-TestArtifactsWithNonTestScope:
-'''
-
-assert analysis == expected
+public class Dollar$Class {}

--- a/src/it/topLevelDollarClassReference/pom.xml
+++ b/src/it/topLevelDollarClassReference/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.shared.dependency-analyzer.tests</groupId>
+  <artifactId>top-level-dollar-class-reference</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>library</module>
+    <module>consumer</module>
+  </modules>
+</project>

--- a/src/it/topLevelDollarClassReference/verify.groovy
+++ b/src/it/topLevelDollarClassReference/verify.groovy
@@ -21,8 +21,7 @@ def analysis = new File( basedir, 'consumer/target/analysis.txt' ).text
 
 def expected = '''
 UsedDeclaredArtifacts:
- org.apache.maven.shared.dependency-analyzer.tests:nested-class-library:jar:1.0:compile
- org.jetbrains.kotlin:kotlin-stdlib:jar:2.4.10:compile
+ org.apache.maven.shared.dependency-analyzer.tests:dollar-class-library:jar:1.0:compile
 
 UsedUndeclaredArtifactsWithClasses:
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
@@ -48,11 +48,9 @@ public class CollectorClassFileVisitor implements ClassFileVisitor {
     /** {@inheritDoc} */
     @Override
     public void visitClass(String className, InputStream in) {
-        // inner classes have equivalent compilation requirement as container class
-        int innerClassSeparator = className.indexOf('$');
-        String containerClass = innerClassSeparator < 0 ? className : className.substring(0, innerClassSeparator);
-        if (!excludedClasses.isMatch(containerClass)) {
-            classes.add(containerClass);
+        // '$' is legal in a top-level class name, so nesting cannot be inferred from the binary name.
+        if (!excludedClasses.isMatch(className)) {
+            classes.add(className);
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
@@ -49,8 +49,10 @@ public class CollectorClassFileVisitor implements ClassFileVisitor {
     @Override
     public void visitClass(String className, InputStream in) {
         // inner classes have equivalent compilation requirement as container class
-        if (className.indexOf('$') < 0 && !excludedClasses.isMatch(className)) {
-            classes.add(className);
+        int innerClassSeparator = className.indexOf('$');
+        String containerClass = innerClassSeparator < 0 ? className : className.substring(0, innerClassSeparator);
+        if (!excludedClasses.isMatch(containerClass)) {
+            classes.add(containerClass);
         }
     }
 

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -109,9 +109,9 @@ public class ResultCollector {
      */
     public void add(final String usedByClass, final String name) {
         // inner classes have equivalent compilation requirement as container class
-        if (name.indexOf('$') < 0) {
-            classUsages.add(new DependencyUsage(name, usedByClass));
-        }
+        int innerClassSeparator = name.indexOf('$');
+        String containerClass = innerClassSeparator < 0 ? name : name.substring(0, innerClassSeparator);
+        classUsages.add(new DependencyUsage(containerClass, usedByClass));
     }
 
     void addNames(final String usedByClass, final String[] names) {

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -108,10 +108,8 @@ public class ResultCollector {
      * @param name a {@link java.lang.String} object.
      */
     public void add(final String usedByClass, final String name) {
-        // inner classes have equivalent compilation requirement as container class
-        int innerClassSeparator = name.indexOf('$');
-        String containerClass = innerClassSeparator < 0 ? name : name.substring(0, innerClassSeparator);
-        classUsages.add(new DependencyUsage(containerClass, usedByClass));
+        // '$' is legal in a top-level class name, so nesting cannot be inferred from the binary name.
+        classUsages.add(new DependencyUsage(name, usedByClass));
     }
 
     void addNames(final String usedByClass, final String[] names) {

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitorTest.java
@@ -53,10 +53,10 @@ class CollectorClassFileVisitorTest {
     }
 
     @Test
-    void testVisitInnerClassAsContainer() {
+    void testVisitClassesContainingDollar() {
         visitor.visitClass("a.b.Outer$Inner", null);
         visitor.visitClass("x.y.Outer$Inner$Nested", null);
 
-        assertThat(visitor.getClasses()).containsExactlyInAnyOrder("a.b.Outer", "x.y.Outer");
+        assertThat(visitor.getClasses()).containsExactlyInAnyOrder("a.b.Outer$Inner", "x.y.Outer$Inner$Nested");
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitorTest.java
@@ -51,4 +51,12 @@ class CollectorClassFileVisitorTest {
 
         assertThat(visitor.getClasses()).isEqualTo(expected);
     }
+
+    @Test
+    void testVisitInnerClassAsContainer() {
+        visitor.visitClass("a.b.Outer$Inner", null);
+        visitor.visitClass("x.y.Outer$Inner$Nested", null);
+
+        assertThat(visitor.getClasses()).containsExactlyInAnyOrder("a.b.Outer", "x.y.Outer");
+    }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultClassAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultClassAnalyzerTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.jar.JarOutputStream;
@@ -89,6 +90,20 @@ class DefaultClassAnalyzerTest {
         } catch (ZipException e) {
             assertThat(e).hasMessageStartingWith("Cannot process Jar entry on URL:");
         }
+    }
+
+    @Test
+    void testAnalyzeDirectoryPreservesDollarClassNames() throws IOException {
+        Path directory = Files.createDirectories(tempDir.resolve("classes/library"));
+        Files.write(directory.resolve("Dollar$Class.class"), new byte[0]);
+        Files.write(directory.resolve("Outer$Inner.class"), new byte[0]);
+
+        DefaultClassAnalyzer analyzer = new DefaultClassAnalyzer();
+        Set<String> actualClasses = analyzer.analyze(
+                tempDir.resolve("classes").toUri().toURL(),
+                new ClassesPatterns(Collections.singleton("library\\.Outer\\$Inner")));
+
+        assertThat(actualClasses).containsExactly("library.Dollar$Class");
     }
 
     private void addZipEntry(JarOutputStream out, String fileName, String content) throws IOException {

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
@@ -118,12 +118,9 @@ class ResultCollectorTest {
     }
 
     @Test
-    void testInnerClassAsContainer() throws IOException {
+    void testInnerClassNamePreserved() throws IOException {
         Set<String> dependencies = getDependencies(InnerClassCase.class);
-        for (String dependency : dependencies) {
-            assertThat(dependency).doesNotContain("$");
-        }
-        assertThat(dependencies).contains("java.lang.System");
+        assertThat(dependencies).contains("java.lang.System", "java.lang.invoke.MethodHandles$Lookup");
     }
 
     @Test
@@ -145,6 +142,6 @@ class ResultCollectorTest {
         DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
         visitor.visitClass("consumer.Example", new ByteArrayInputStream(writer.toByteArray()));
 
-        assertThat(visitor.getDependencies()).contains("dependency.Outer").doesNotContain("dependency.Outer$Inner");
+        assertThat(visitor.getDependencies()).contains("dependency.Outer$Inner").doesNotContain("dependency.Outer");
     }
 }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollectorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.shared.dependency.analyzer.asm;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -31,6 +32,9 @@ import org.apache.maven.shared.dependency.analyzer.testcases.MethodHandleCases;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -120,5 +124,27 @@ class ResultCollectorTest {
             assertThat(dependency).doesNotContain("$");
         }
         assertThat(dependencies).contains("java.lang.System");
+    }
+
+    @Test
+    void testInnerClassWithoutContainerClassInConstantPool() {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V17, Opcodes.ACC_PUBLIC, "consumer/Example", null, "java/lang/Object", null);
+
+        MethodVisitor method = writer.visitMethod(Opcodes.ACC_PUBLIC, "use", "()V", null, null);
+        method.visitCode();
+        method.visitTypeInsn(Opcodes.NEW, "dependency/Outer$Inner");
+        method.visitInsn(Opcodes.DUP);
+        method.visitMethodInsn(Opcodes.INVOKESPECIAL, "dependency/Outer$Inner", "<init>", "()V", false);
+        method.visitInsn(Opcodes.POP);
+        method.visitInsn(Opcodes.RETURN);
+        method.visitMaxs(2, 1);
+        method.visitEnd();
+        writer.visitEnd();
+
+        DependencyClassFileVisitor visitor = new DependencyClassFileVisitor();
+        visitor.visitClass("consumer.Example", new ByteArrayInputStream(writer.toByteArray()));
+
+        assertThat(visitor.getDependencies()).contains("dependency.Outer").doesNotContain("dependency.Outer$Inner");
     }
 }


### PR DESCRIPTION
Fixes apache/maven-dependency-plugin#1345

## Summary

Preserve exact JVM binary class names when collecting dependency usages and dependency artifact contents.

The analyzer previously assumed that every `$` in a binary class name denoted an inner class and discarded or folded that name into its presumed container. Kotlin can emit bytecode that references only a nested class, so the corresponding artifact was incorrectly reported as unused. The assumption was also invalid for legal top-level Java class names containing `$`.

Artifact lookup already deduplicates usages by artifact, so retaining the exact binary name correctly handles both nested classes and top-level names without independently inferring the source-level compilation unit.

The change adds:

- a Kotlin integration test reproducing the nested-class-only reference;
- an integration test for a genuine top-level Java class containing `$`;
- unit coverage for exact usage collection and exploded dependency directories.

## Verification

- `mvn -Prun-its verify` with JDK 17: 128 unit tests and all 21 invoker builds passed.
- Focused Kotlin and top-level-dollar integration tests passed with JDK 8 and JDK 17.
- The original Dropwizard/Kotlin reproducer completed without dependency-analysis warnings.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
