### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassAnalyzer.java
@@ -44,6 +44,7 @@ public interface ClassAnalyzer {
      * <p>analyze.</p>
      *
      * @param url the JAR file or directory to analyze
+     * @param excludedClasses patterns of classes to exclude
      * @return a {@link java.util.Set} object
      * @throws java.io.IOException if any
      */

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassFileVisitor.java
@@ -27,5 +27,11 @@ import java.io.InputStream;
  */
 public interface ClassFileVisitor {
 
+    /**
+     * Visits a class file.
+     *
+     * @param className class name
+     * @param in class file contents
+     */
     void visitClass(String className, InputStream in);
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassesPatterns.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ClassesPatterns.java
@@ -43,10 +43,17 @@ public class ClassesPatterns {
         }
     }
 
+    /** Creates an empty set of patterns. */
     public ClassesPatterns() {
         this.patterns = Collections.emptySet();
     }
 
+    /**
+     * Checks whether a class name matches a pattern.
+     *
+     * @param className class name to check
+     * @return whether the class name matches
+     */
     public boolean isMatch(String className) {
         if (patterns.isEmpty()) {
             return false;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/CollectorClassFileVisitor.java
@@ -40,6 +40,11 @@ public class CollectorClassFileVisitor implements ClassFileVisitor {
         this(new ClassesPatterns());
     }
 
+    /**
+     * Creates a visitor with excluded class patterns.
+     *
+     * @param excludedClasses patterns of classes to exclude
+     */
     public CollectorClassFileVisitor(ClassesPatterns excludedClasses) {
         classes = new HashSet<>();
         this.excludedClasses = excludedClasses;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -326,6 +326,14 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         abstract boolean includes(String scope);
     }
 
+    /**
+     * Maps dependency artifacts to their classes.
+     *
+     * @param project Maven project
+     * @param excludedClasses patterns of classes to exclude
+     * @return dependency artifacts and their classes
+     * @throws IOException if a dependency cannot be read
+     */
     protected Map<Artifact, Set<String>> buildArtifactClassMap(MavenProject project, ClassesPatterns excludedClasses)
             throws IOException {
         Map<Artifact, Set<String>> artifactClassMap = new LinkedHashMap<>();

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyAnalyzer.java
@@ -59,6 +59,7 @@ public interface DependencyAnalyzer {
      * <p>analyzeUsages.</p>
      *
      * @param url the JAR file or directory to analyze
+     * @param excludeClasses patterns of classes to exclude
      * @return the set of class names referenced by the library, paired with the
      * classes declaring those references.
      * @throws IOException if an error occurs reading a JAR or .class file

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyClassesProvider.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyClassesProvider.java
@@ -34,6 +34,7 @@ public interface DependencyClassesProvider {
      * @param project         the Maven project
      * @param excludedClasses patterns of classes to exclude
      * @return the set of dependency usages
+     * @throws IOException if dependency classes cannot be read
      */
     Set<DependencyUsage> getDependencyClasses(MavenProject project, ClassesPatterns excludedClasses) throws IOException;
 }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyUsage.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DependencyUsage.java
@@ -29,6 +29,12 @@ public class DependencyUsage {
 
     private final String usedBy;
 
+    /**
+     * Creates a dependency usage.
+     *
+     * @param dependencyClass referenced dependency class
+     * @param usedBy class containing the reference
+     */
     public DependencyUsage(String dependencyClass, String usedBy) {
         this.dependencyClass = dependencyClass;
         this.usedBy = usedBy;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/ProjectDependencyAnalysis.java
@@ -88,6 +88,14 @@ public class ProjectDependencyAnalysis {
                 testArtifactsWithNonTestScope);
     }
 
+    /**
+     * Creates an analysis result with usage details.
+     *
+     * @param usedDeclaredArtifacts artifacts both used and declared
+     * @param usedUndeclaredArtifacts artifacts used but not declared
+     * @param unusedDeclaredArtifacts artifacts declared but not used
+     * @param testArtifactsWithNonTestScope artifacts only used in tests but not declared with test scope
+     */
     public ProjectDependencyAnalysis(
             Map<Artifact, Set<DependencyUsage>> usedDeclaredArtifacts,
             Map<Artifact, Set<DependencyUsage>> usedUndeclaredArtifacts,
@@ -145,6 +153,11 @@ public class ProjectDependencyAnalysis {
         return usedUndeclaredArtifactsWithClasses;
     }
 
+    /**
+     * Returns artifacts used but not declared with their usages.
+     *
+     * @return artifacts used but not declared with their usages
+     */
     public Map<Artifact, Set<DependencyUsage>> getUsedUndeclaredArtifactsWithUsages() {
         return safeCopy(usedUndeclaredArtifacts);
     }

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultAnnotationVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultAnnotationVisitor.java
@@ -37,6 +37,7 @@ public class DefaultAnnotationVisitor extends AnnotationVisitor {
      * <p>Constructor for DefaultAnnotationVisitor.</p>
      *
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param usedByClass class containing the reference
      */
     public DefaultAnnotationVisitor(ResultCollector resultCollector, String usedByClass) {
         super(Opcodes.ASM9);

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultClassVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultClassVisitor.java
@@ -54,6 +54,7 @@ public class DefaultClassVisitor extends ClassVisitor {
      * @param fieldVisitor a {@link org.objectweb.asm.FieldVisitor} object.
      * @param methodVisitor a {@link org.objectweb.asm.MethodVisitor} object.
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param usedByClass class containing the reference
      */
     public DefaultClassVisitor(
             SignatureVisitor signatureVisitor,

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultFieldVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultFieldVisitor.java
@@ -40,6 +40,7 @@ public class DefaultFieldVisitor extends FieldVisitor {
      *
      * @param annotationVisitor a {@link org.objectweb.asm.AnnotationVisitor} object.
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param usedByClass class containing the reference
      */
     public DefaultFieldVisitor(
             AnnotationVisitor annotationVisitor, ResultCollector resultCollector, String usedByClass) {

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultMethodVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultMethodVisitor.java
@@ -51,6 +51,7 @@ public class DefaultMethodVisitor extends MethodVisitor {
      * @param annotationVisitor a {@link org.objectweb.asm.AnnotationVisitor} object.
      * @param signatureVisitor a {@link org.objectweb.asm.signature.SignatureVisitor} object.
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param usedByClass class containing the reference
      */
     public DefaultMethodVisitor(
             AnnotationVisitor annotationVisitor,

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DefaultSignatureVisitor.java
@@ -35,6 +35,7 @@ public class DefaultSignatureVisitor extends SignatureVisitor {
      * <p>Constructor for DefaultSignatureVisitor.</p>
      *
      * @param resultCollector a {@link org.apache.maven.shared.dependency.analyzer.asm.ResultCollector} object.
+     * @param usedByClass class containing the reference
      */
     public DefaultSignatureVisitor(ResultCollector resultCollector, String usedByClass) {
         super(Opcodes.ASM9);

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/DependencyClassFileVisitor.java
@@ -50,6 +50,8 @@ public class DependencyClassFileVisitor implements ClassFileVisitor {
 
     /**
      * <p>Constructor for DependencyClassFileVisitor.</p>
+     *
+     * @param excludedClasses patterns of classes to exclude
      */
     public DependencyClassFileVisitor(ClassesPatterns excludedClasses) {
         this.excludedClasses = excludedClasses;

--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ResultCollector.java
@@ -57,6 +57,7 @@ public class ResultCollector {
     /**
      * <p>addName.</p>
      *
+     * @param usedByClass class containing the reference
      * @param name a {@link java.lang.String} object.
      */
     public void addName(final String usedByClass, String name) {
@@ -105,6 +106,7 @@ public class ResultCollector {
     /**
      * <p>add.</p>
      *
+     * @param usedByClass class containing the reference
      * @param name a {@link java.lang.String} object.
      */
     public void add(final String usedByClass, final String name) {


### PR DESCRIPTION
## Summary

Add concise documentation for the public APIs reported by Javadoc.

The reporting build emitted 19 warnings for missing comments, parameters, return values, and an exception. This change supplies only the missing documentation and does not alter runtime behavior.

## Verification

- `mvn -B -V spotless:apply`
- `mvn -B -V clean verify site` with JDK 17: 131 tests passed
- `mvn -B -V -DskipTests -P reporting compile site site:stage` with JDK 17: passed with no Javadoc warnings
- `mvn -B -V spotless:check`

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This change has no runtime behavior.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).
  Integration tests were not run because this change only adds Javadocs.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
