### PR TITLE
Fix filtered graph resolved artifacts

### DIFF
--- a/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
+++ b/src/main/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzer.java
@@ -422,8 +422,15 @@ public class DefaultProjectDependencyAnalyzer implements ProjectDependencyAnalyz
         @Override
         @SuppressWarnings("deprecation")
         public Set<Artifact> getDependencyArtifacts() {
-            // Make ProjectDependenciesResolver collect the filtered model dependencies while retaining all other
-            // decorator-visible state copied by MavenProject(MavenProject).
+            // Make ProjectDependenciesResolver collect the filtered model dependencies rather than reusing the
+            // copied resolved state.
+            return null;
+        }
+
+        @Override
+        public Set<Artifact> getArtifacts() {
+            // ProjectDependenciesResolver otherwise reads the source project's copied resolved artifacts, including
+            // the candidates that this graph intentionally excludes.
             return null;
         }
     }

--- a/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
+++ b/src/test/java/org/apache/maven/shared/dependency/analyzer/DefaultProjectDependencyAnalyzerTest.java
@@ -314,7 +314,7 @@ class DefaultProjectDependencyAnalyzerTest {
                     .noneMatch(dependency -> dependency.getArtifactId().endsWith("candidate"));
             assertThat(graphProject.getOriginalModel()).isSameAs(originalModel);
             assertThat(graphProject.getActiveProfiles()).containsExactly(activeProfile);
-            assertThat(graphProject.getArtifacts()).containsExactly(resolvedState);
+            assertThat(graphProject.getArtifacts()).isNull();
             assertThat(graphProject.getManagedVersionMap()).isSameAs(managedVersionMap);
             assertThat(graphProject.isExecutionRoot()).isTrue();
         });


### PR DESCRIPTION
Closes #301

## Summary

DependencyGraphProject copies the source MavenProject, including its resolved
artifact set. The filtered graph replaces getDependencyArtifacts() with null,
but the inherited getArtifacts() still exposes that copied resolved state to
ProjectDependenciesResolver. As a result, a candidate intentionally excluded
from the graph can still be considered resolved.

Override getArtifacts() as well, so the resolver obtains the graph's filtered
dependency state. The regression test verifies that the copied resolved artifacts
are no longer exposed.

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Run mvn verify to make sure basic checks pass.
- [x] You have run the integration tests successfully (mvn -Prun-its verify).
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
